### PR TITLE
Adding ReadTheDocs template + switching to .rst write-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.png
 *.pdf
 
+# ignore docs build folder
+
+docs/_build/
+
 # ignore temp files or executable files
 *.pyc
 *.log

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ Detailed documentation regarding the framework can be found in the dedicated `Re
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
-1. CMSSW and cobmine release setup
+1. Setup the correct CMSSW and Combine releases
 =========================================
-These are formed from from `Combine official instructions <https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/>`_.
+These are formed from from the `official Combine framework instructions <https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/>`_.
 
 CC7 release CMSSW_10_2_X - recommended version
 Setting up the environment (once): ::
@@ -39,6 +39,11 @@ Final step is to clone the correct verison of the code. At the moment the workin
   git clone -b CMSSW_10_X git@github.com:vukasinmilosevic/Fiducial_XS.git
   cd Fiducial_XS
 
+2. Running the measurement
+=========================================
+
+2.1 Using the ``RunEverythin.py`` script:
+-----------------------------------------
 
 Now, all steps can be run using script `RunEverything.py`. The available options are: ::
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 ======================================
+Detailed documentation regarding the framework can be found :target: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+.. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
-:target: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
-:alt: Documentation Status
 
 ## 1. CMSSW and cobmine release setup
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated ReadTheDocs page:
-https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs page`_:
+.. _ReadTheDocs page: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
@@ -15,16 +15,13 @@ Taken from Combine official instructions: https://cms-analysis.github.io/HiggsAn
 CC7 release CMSSW_10_2_X - recommended version
 Setting up the environment (once):
 
-# Equivalent
-
+.. code-block::
 export SCRAM_ARCH=slc7_amd64_gcc700
 cmsrel CMSSW_10_2_13
 cd CMSSW_10_2_13/src
 cmsenv
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
-
-# Equivalent
 
 Update to a recommended tag - currently the recommended tag is v8.2.0: see release notes
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,8 @@ Detailed documentation regarding the framework can be found in the dedicated `Re
 
 1. CMSSW and cobmine release setup
 =========================================
-Taken from Combine official instructions: https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/
+These are formed from from `Combine official instructions <https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/>`_. 
+.. |caution| image:: warning.png
 
 CC7 release CMSSW_10_2_X - recommended version
 Setting up the environment (once)::

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,9 @@ FiducialXS README Page
 Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page. This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Text Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``. For more details about the Markup syntax, please consult the `ReStructuredText Primer <https://docutils.sourceforge.io/docs/user/rst/quickstart.html>`_.
+Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.
+This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Text Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``.
+For more details about the Markup syntax, please consult the `ReStructuredText Primer <https://docutils.sourceforge.io/docs/user/rst/quickstart.html>`_.
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated 'ReadTheDocs page'_:
-.. _'ReadTheDocs page': https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+Detailed documentation regarding the framework can be found in the dedicated ReadTheDocs_ page:
+.. _ReadTheDocs: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Dependencies:
 .. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen
 
 Framework/documentation:
+
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.

--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,10 @@ Detailed documentation regarding the framework can be found in the dedicated `Re
 
 1. CMSSW and cobmine release setup
 =========================================
-These are formed from from `Combine official instructions <https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/>`_. 
-.. |caution| image:: warning.png
+These are formed from from `Combine official instructions <https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/>`_.
 
 CC7 release CMSSW_10_2_X - recommended version
-Setting up the environment (once)::
+Setting up the environment (once): ::
 
   export SCRAM_ARCH=slc7_amd64_gcc700
   cmsrel CMSSW_10_2_13
@@ -22,58 +21,55 @@ Setting up the environment (once)::
   git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
   cd HiggsAnalysis/CombinedLimit
 
-Update to a recommended tag - currently the recommended tag is v8.2.0: see release notes
+Update to a recommended tag - currently the recommended tag is v8.2.0: see release notes: ::
 
-```
-cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit
-git fetch origin
-git checkout v8.2.0
-scramv1 b clean; scramv1 b # always make a clean build
-```
-Depending on where the data/mc is stored, one might need:
 
-```
-voms-proxy-init -voms cms
-```
-Final step is to clone the correct verison of the code. At the moment the working version can be found on the ```CMSSW_10_X``` branch, which can be cloned via the following command:
-```
-cd $CMSSW_BASE/src/
-#git clone -b CMSSW_10_X git@github.com:vukasinmilosevic/Fiducial_XS.git
-git clone -b CMSSW_10_X_Dev2 git@github.com:ram1123/Fiducial_XS.git
-cd Fiducial_XS
-```
+  cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit
+  git fetch origin
+  git checkout v8.2.0
+  scramv1 b clean; scramv1 b # always make a clean build
 
-Now, all steps can be run using script `RunEverything.py`. All available options are:
+Depending on where the data/mc is stored, one might need: ::
 
-```
-usage: RunEverything.py [-h] [-s {1,2,3,4,5}] [-c CHANNELS [CHANNELS ...]]
+  voms-proxy-init -voms cms
+
+Final step is to clone the correct verison of the code. At the moment the working version can be found on the ```CMSSW_10_X``` branch, which can be cloned via the following command: ::
+
+  cd $CMSSW_BASE/src/
+  git clone -b CMSSW_10_X git@github.com:vukasinmilosevic/Fiducial_XS.git
+  cd Fiducial_XS
+
+
+Now, all steps can be run using script `RunEverything.py`. The available options are: ::
+
+
+  usage: RunEverything.py [-h] [-s {1,2,3,4,5}] [-c CHANNELS [CHANNELS ...]]
                         [-p NTUPLEDIR] [-m HIGGSMASS] [-r {0,1}]
 
-Input arguments
+  Input arguments
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -s {1,2,3,4,5}        Which step to run
-  -c CHANNELS [CHANNELS ...]
-                        list of channels
-  -p NTUPLEDIR          Path of ntuples
-  -m HIGGSMASS          Higgs mass
-  -r {0,1}              if 1 then it will run the commands else it will just
-                        print the commands
-```
+  optional arguments:
+    -h, --help            show this help message and exit
+    -s {1,2,3,4,5}        Which step to run
+    -c CHANNELS [CHANNELS ...]
+                          list of channels
+    -p NTUPLEDIR          Path of ntuples
+    -m HIGGSMASS          Higgs mass
+    -r {0,1}              if 1 then it will run the commands else it will just
+                          print the commands
 
-Command to run:
+Commands to run: ::
 
-```bash
-python RunEverything.py -r 1 -s 1 # step-1
-python RunEverything.py -r 1 -s 2 # step-2
-python RunEverything.py -r 1 -s 3 # step-3
-python RunEverything.py -r 1 -s 4 # step-4
-python RunEverything.py -r 1 -s 5 # step-5
-```
 
-# Detailed instructions
+  python RunEverything.py -r 1 -s 1 # step-1
+  python RunEverything.py -r 1 -s 2 # step-2
+  python RunEverything.py -r 1 -s 3 # step-3
+  python RunEverything.py -r 1 -s 4 # step-4
+  python RunEverything.py -r 1 -s 5 # step-5
 
+
+Detailed instructions
+----------------------
 ## 2. Running the measurement
 
 ### 2.1 Running the efficiencies step

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Framework/documentation:
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.
-This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Text Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``.
+This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Text Markup syntax) in order to better explore the options given by ``sphinx`` and ``ReadTheDocs``.
 For more details about the Markup syntax, please consult the `ReStructuredText Primer <https://docutils.sourceforge.io/docs/user/rst/quickstart.html>`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 
 =========================================
-FiducialXS ReadMe Page
+FiducialXS README Page
 =========================================
 Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.
+Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page. This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``.
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,10 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 ======================================
 
-Detailed documentation regarding the framework can be found https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+Detailed documentation regarding the framework can be found in the dedicated ReadTheDocs page:
+https://fiducialxs.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_X&color=brightgreen
+.. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 ## 1. CMSSW and cobmine release setup

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ Final step is to clone the correct verison of the code. At the moment the workin
 2. Running the measurement
 =========================================
 
-2.1 Using the `RunEverything.py` script:
+2.1 Using the ``RunEverything.py`` script:
 -----------------------------------------
 
-Now, all steps can be run using script `RunEverything.py`. The available options are: ::
+Now, all steps can be run using script ``RunEverything.py``. The available options are: ::
 
 
   usage: RunEverything.py [-h] [-s {1,2,3,4,5}] [-c CHANNELS [CHANNELS ...]]
@@ -73,66 +73,64 @@ Commands to run: ::
   python RunEverything.py -r 1 -s 5 # step-5
 
 
-Detailed instructions
-----------------------
-## 2. Running the measurement
+2.2 Detailed, step-by-step instructions
+---------------------------------------
 
-### 2.1 Running the efficiencies step
+2.2.1 Running the efficiencies step
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Current example running ```mass4l``` variable via ```nohup```. For local testing remove ```nohup``` (and pipelining into a .log file if wanting terminal printout).
+Current example running ``mass4l`` variable via ``nohup``. For local testing remove ``nohup`` (and pipelining into a .log file if wanting terminal printout). ::
 
-```
-nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "4mu" >& effs_mass4l_4mu.log &
-nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "4e" >& effs_mass4l_4e.log &
-nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "2e2mu" >& effs_mass4l_2e2mu.log &
-nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "4l" >& effs_mass4l_4l.log &
+  nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "4mu" >& effs_mass4l_4mu.log &
+  nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "4e" >& effs_mass4l_4e.log &
+  nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "2e2mu" >& effs_mass4l_2e2mu.log &
+  nohup python -u efficiencyFactors.py -l -q -b --obsName="mass4l" --obsBins="|105.0|140.0|" -c "4l" >& effs_mass4l_4l.log &
 
-python collectInputs.py # currently only active for mass4l, calls be uncommented for the rest of variables
-```
+  python collectInputs.py # currently only active for mass4l, calls be uncommented for the rest of variables
 
-Running the plotter:
+Running the plotter: ::
 
-```
-#skipping for mass4l
-#python -u plot2dsigeffs.py -l -q -b --obsName="pT4l" --obsBins="|0|10|20|30|45|80|120|200|13000|"
-```
-
-### 2.2. Running the uncertainties step
-
-```
-python -u getUnc_Unc.py --obsName="mass4l" --obsBins="|105.0|140.0|" >& unc_mass4l.log &
-```
-
-### 2.3 Running the background template maker
-
-```
-python -u runHZZFiducialXS.py --dir="/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/" --obsName="mass4l" --obsBins="|105.0|140.0|" --redoTemplates --templatesOnly
-```
-
-### 2.4 Runing the final measurement and plotters
-
-For the last step a data file is needed as input, even for the blinded step (!). I've stored the previous one in my public folder:
-```
-/afs/cern.ch/user/v/vmilosev/public/data_13TeV.root
-```
-or one can copy the data file from the data/mc folder and properly rename it. One additional set of models is needed in order to run the combine step. The HZZ4l specific modules stored here:
-```
-/afs/cern.ch/user/v/vmilosev/public/HZZ4l_models/
-```
-needs to be added to the corresponding ```$CMSSW_BASE/src/HiggsAnalysis/CombinedLimit/python``` collection of libraries.
-
-The command to run the measurement and the plotters is:
+  #skipping for mass4l
+  #python -u plot2dsigeffs.py -l -q -b --obsName="pT4l" --obsBins="|0|10|20|30|45|80|120|200|13000|"
 
 
-```
-nohup python -u runHZZFiducialXS.py --obsName="mass4l" --obsBins="|105.0|140.0|"  --calcSys --asimovMass 125.0  >& log_mass4l_Run2Fid.txt &
-```
+2.2.2. Running the uncertainties step::
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-# Things to fix
+  python -u getUnc_Unc.py --obsName="mass4l" --obsBins="|105.0|140.0|" >& unc_mass4l.log &
+  
 
-## Specific
+2.2.3 Running the background template maker::
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  python -u runHZZFiducialXS.py --dir="/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/" --obsName="mass4l" --obsBins="|105.0|140.0|" --redoTemplates --templatesOnly
+
+
+2.2.4 Runing the final measurement and plotters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For the last step a data file is needed as input, even for the blinded step (!). I've stored the previous one in my public folder: ::
+
+  /afs/cern.ch/user/v/vmilosev/public/data_13TeV.root
+  
+or one can copy the data file from the data/mc folder and properly rename it. One additional set of models is needed in order to run the combine step. The HZZ4l specific modules stored here: ::
+
+  /afs/cern.ch/user/v/vmilosev/public/HZZ4l_models/
+
+needs to be added to the corresponding ``$CMSSW_BASE/src/HiggsAnalysis/CombinedLimit/python`` collection of libraries.
+
+The command to run the measurement and the plotters is: ::
+
+  nohup python -u runHZZFiducialXS.py --obsName="mass4l" --obsBins="|105.0|140.0|"  --calcSys --asimovMass 125.0  >& log_mass4l_Run2Fid.txt &
+
+
+Things to fix
+-------------------
+Specific
+^^^^^^^^^^^^^^^^^^^
 1. Hardcoded paths in [LoadData.py](python/LoadData.py#8)
 
-## General
+General
+^^^^^^^^^^^^^^^^^^
 
 1. Add the `choices` for argparser whereever its possible. So, that code won't run if we provide wrong arguments.

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs page`_:
-.. _`ReadTheDocs page`: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+Detailed documentation regarding the framework can be found in the dedicated 'ReadTheDocs page'_:
+.. _'ReadTheDocs page': https://fiducialxs.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
+=========================================
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
-======================================
+=========================================
 
 Detailed documentation regarding the framework can be found in the dedicated ReadTheDocs page:
 https://fiducialxs.readthedocs.io/en/latest/?badge=latest
@@ -7,21 +8,23 @@ https://fiducialxs.readthedocs.io/en/latest/?badge=latest
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
-## 1. CMSSW and cobmine release setup
-
+1. CMSSW and cobmine release setup
+=========================================
 Taken from Combine official instructions: https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/
 
 CC7 release CMSSW_10_2_X - recommended version
 Setting up the environment (once):
 
-```
+# Equivalent
+
 export SCRAM_ARCH=slc7_amd64_gcc700
 cmsrel CMSSW_10_2_13
 cd CMSSW_10_2_13/src
 cmsenv
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
-```
+
+# Equivalent
 
 Update to a recommended tag - currently the recommended tag is v8.2.0: see release notes
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 =========================================
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs page`_:
-.. _ReadTheDocs page: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+.. _`ReadTheDocs page`: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ Things to fix
 -------------------
 Specific
 ^^^^^^^^^^^^^^^^^^^
-1. Hardcoded paths in `LoadData.py <https://github.com/vukasinmilosevic/Fiducial_XS/edit/CMSSW_10_X_VM_docs/python/LoadData.py#8/`_
+1. Hardcoded paths in `LoadData.py <https://github.com/vukasinmilosevic/Fiducial_XS/edit/CMSSW_10_X_VM_docs/python/LoadData.py#8/>`_
 
 General
 ^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 ======================================
-Detailed documentation regarding the framework can be found :target: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+
+Detailed documentation regarding the framework can be found https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ FiducialXS README Page
 Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page. This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``.
+Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page. This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Text Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``. For more details about the Markup syntax, please consult the `ReStructuredText Primer <https://docutils.sourceforge.io/docs/user/rst/quickstart.html>`_.
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,8 @@
-# Instructions to run the BBBF differential xs code for CMSSW_10_X releases
+Instructions to run the BBBF differential xs code for CMSSW_10_X releases
+======================================
+.. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
+:target: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+:alt: Documentation Status
 
 ## 1. CMSSW and cobmine release setup
 

--- a/README.rst
+++ b/README.rst
@@ -94,14 +94,15 @@ Running the plotter: ::
   #python -u plot2dsigeffs.py -l -q -b --obsName="pT4l" --obsBins="|0|10|20|30|45|80|120|200|13000|"
 
 
-2.2.2. Running the uncertainties step ::
+2.2.2. Running the uncertainties step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+::
   python -u getUnc_Unc.py --obsName="mass4l" --obsBins="|105.0|140.0|" >& unc_mass4l.log &
   
 
-2.2.3 Running the background template maker ::
+2.2.3 Running the background template maker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
 
   python -u runHZZFiducialXS.py --dir="/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/" --obsName="mass4l" --obsBins="|105.0|140.0|" --redoTemplates --templatesOnly
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 =========================================
 FiducialXS ReadMe Page
 =========================================
-Instructions to run the BBBF differential xs code for CMSSW_10_X releases (xBF team, 2022)
+Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.

--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,16 @@ FiducialXS README Page
 =========================================
 Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
+Versions:
+^^^^^^^^^
+.. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
+.. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen
+.. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.
 This ``README`` file and the official documentation are written in ``.rst`` (ReStructured Text Markup syntax) in order to better explore the options given by ``sphinx/ReadTheDocs``.
 For more details about the Markup syntax, please consult the `ReStructuredText Primer <https://docutils.sourceforge.io/docs/user/rst/quickstart.html>`_.
 
-.. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
-.. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen
-.. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 1. Setup the correct CMSSW and Combine releases
 =========================================

--- a/README.rst
+++ b/README.rst
@@ -12,15 +12,14 @@ Detailed documentation regarding the framework can be found in the dedicated `Re
 Taken from Combine official instructions: https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/
 
 CC7 release CMSSW_10_2_X - recommended version
-Setting up the environment (once):
+Setting up the environment (once)::
 
-.. code-block::
-export SCRAM_ARCH=slc7_amd64_gcc700
-cmsrel CMSSW_10_2_13
-cd CMSSW_10_2_13/src
-cmsenv
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-cd HiggsAnalysis/CombinedLimit
+  export SCRAM_ARCH=slc7_amd64_gcc700
+  cmsrel CMSSW_10_2_13
+  cd CMSSW_10_2_13/src
+  cmsenv
+  git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+  cd HiggsAnalysis/CombinedLimit
 
 Update to a recommended tag - currently the recommended tag is v8.2.0: see release notes
 

--- a/README.rst
+++ b/README.rst
@@ -94,13 +94,13 @@ Running the plotter: ::
   #python -u plot2dsigeffs.py -l -q -b --obsName="pT4l" --obsBins="|0|10|20|30|45|80|120|200|13000|"
 
 
-2.2.2. Running the uncertainties step::
+2.2.2. Running the uncertainties step ::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   python -u getUnc_Unc.py --obsName="mass4l" --obsBins="|105.0|140.0|" >& unc_mass4l.log &
   
 
-2.2.3 Running the background template maker::
+2.2.3 Running the background template maker ::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   python -u runHZZFiducialXS.py --dir="/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/" --obsName="mass4l" --obsBins="|105.0|140.0|" --redoTemplates --templatesOnly
@@ -128,7 +128,7 @@ Things to fix
 -------------------
 Specific
 ^^^^^^^^^^^^^^^^^^^
-1. Hardcoded paths in [LoadData.py](python/LoadData.py#8)
+1. Hardcoded paths in `LoadData.py <https://github.com/vukasinmilosevic/Fiducial_XS/edit/CMSSW_10_X_VM_docs/python/LoadData.py#8/`_
 
 General
 ^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,9 @@ FiducialXS README Page
 =========================================
 Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
+
 Versions:
-^^^^^^^^^
+
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Final step is to clone the correct verison of the code. At the moment the workin
 2. Running the measurement
 =========================================
 
-2.1 Using the ``RunEverythin.py`` script:
+2.1 Using the `RunEverything.py` script:
 -----------------------------------------
 
 Now, all steps can be run using script `RunEverything.py`. The available options are: ::

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 
 =========================================
-FiducialXS Readme Page
+FiducialXS ReadMe Page
 =========================================
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases (xBF team, 2022)
 =========================================

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,7 @@
 Instructions to run the BBBF differential xs code for CMSSW_10_X releases
 =========================================
 
-Detailed documentation regarding the framework can be found in the dedicated ReadTheDocs_ page:
-.. _ReadTheDocs: https://fiducialxs.readthedocs.io/en/latest/?badge=latest
+Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,12 @@ FiducialXS README Page
 Instructions to run the xBF team's framework for differential cross-section measurements for CMSSW_10_X releases.
 =========================================
 
-Versions:
+Dependencies:
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
 .. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen
+
+Framework/documentation:
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
+
 =========================================
-Instructions to run the BBBF differential xs code for CMSSW_10_X releases
+FiducialXS Readme Page
+=========================================
+Instructions to run the BBBF differential xs code for CMSSW_10_X releases (xBF team, 2022)
 =========================================
 
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ Running the plotter: ::
 2.2.2. Running the uncertainties step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
+
   python -u getUnc_Unc.py --obsName="mass4l" --obsBins="|105.0|140.0|" >& unc_mass4l.log &
   
 

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,7 @@ Instructions to run the xBF team's framework for differential cross-section meas
 Detailed documentation regarding the framework can be found in the dedicated `ReadTheDocs <https://fiducialxs.readthedocs.io/en/latest/?badge=latest>`_ page.
 
 .. image:: https://img.shields.io/static/v1?label=CMSSW%20version&message=10_2_X&color=brightgreen
+.. image:: https://img.shields.io/static/v1?label=Combine%20version&message=8_2_0&color=brightgreen
 .. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
 
 1. Setup the correct CMSSW and Combine releases

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import sys
 sys.path.insert(0, os.path.abspath('../'))
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+#html_theme = 'alabaster'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 #
 # import os
 # import sys
- sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('../'))
 
 project = 'FiducialXS'
 copyright = '2022, Vukasin Milosevic & Ram Sharma'
-author = 'Vukasin Milosevic & Ram Sharma'
+author = 'xBF Working Group (CMS Collaboration, CERN)'
 
 # The full version, including alpha/beta/rc tags
 release = '0.0.1'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'FiducialXS'
+copyright = '2022, Vukasin Milosevic & Ram Sharma'
+author = 'Vukasin Milosevic & Ram Sharma'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 #
 # import os
 # import sys
-# sys.path.insert(0, os.path.abspath('.'))
+ sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'FiducialXS'
-copyright = '2022, Vukasin Milosevic & Ram Sharma'
-author = 'xBF Working Group (CMS Collaboration, CERN)'
+copyright = '2022, xBF Working Group (CMS Collaboration, CERN)'
+author = 'Vukasin Milosevic & Ram Sharma'
 
 # The full version, including alpha/beta/rc tags
 release = '0.0.1'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 The xBF group's Fiducial XS Primer
 ======================================
 
-This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `REDME <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
+This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `README <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
 
 [TBC]
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,8 @@
 The xBF group's Fiducial XS Primer
 ======================================
 
+.. image:: https://readthedocs.org/projects/fiducialxs/badge/?version=latest
+
 This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `README <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step, which is why new students are highly encouraged to explore this route.
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to FiducialXS's documentation!
+Documantation for the Fiducial XS framework
 ======================================
+
+This page will provide examples for the analysis currently being prepared under the HIG-21-009 CMS code. 
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Documantation for the Fiducial XS framework
+A Primer for the Fiducial XS framework
 ======================================
 
-This page will provide examples for the analysis currently being prepared under the HIG-21-009 CMS code. 
+This page provide examples and detailed explinations for the entire process of differential cross-section measurements in the H :math:`\rightarrow` ZZ
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,13 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-A Primer for the Fiducial XS framework
+The xBF group's Fiducial XS Primer
 ======================================
 
-This page provide examples and detailed explinations for the entire process of differential cross-section measurements in the H :math:`\rightarrow` ZZ
+This page serves as a collection of examples and detailed explinations for the process of differential cross-section measurements in the H:math:`\rightarrow`ZZ:math:`\rightarrow`4l channlel. 
+
+[TBC]
+------------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,9 @@ The xBF group's Fiducial XS Primer
 
 This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `README <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
 
+.. note::
+   Most, if not all, of the examples presented in this page are based on the currently ongoing efforts for the `HIG-21-009 <https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=HIG-21-009&tp=an&id=2445&ancode=HIG-21-009>`_ publicaition.
+
 [TBC]
 ------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 The xBF group's Fiducial XS Primer
 ======================================
 
-This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `README <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
+This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `README <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step, which is why new students are highly encouraged to explore this route.
 
 .. note::
    Most, if not all, of the examples presented in this page are based on the currently ongoing efforts for the `HIG-21-009 <https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=HIG-21-009&tp=an&id=2445&ancode=HIG-21-009>`_ publicaition.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. FiducialXS documentation master file, created by
+   sphinx-quickstart on Mon Feb 28 22:14:39 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to FiducialXS's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 The xBF group's Fiducial XS Primer
 ======================================
 
-This page serves as a collection of examples and detailed explinations for the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. 
+This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official REDME file of the framework's github page. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
 
 [TBC]
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 The xBF group's Fiducial XS Primer
 ======================================
 
-This page serves as a collection of examples and detailed explinations for the process of differential cross-section measurements in the H:math:`\rightarrow`ZZ:math:`\rightarrow`4l channlel. 
+This page serves as a collection of examples and detailed explinations for the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. 
 
 [TBC]
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 The xBF group's Fiducial XS Primer
 ======================================
 
-This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official REDME file of the framework's github page. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
+This page serves as a collection of examples and detailed explinations summarising the process of differential cross-section measurements in the H :math:`\rightarrow` ZZ :math:`\rightarrow` 4l channlel. The very first section (Quick Start) will focus on the practical set of instructions, akin to those found in the official `REDME <https://github.com/vukasinmilosevic/Fiducial_XS/blob/CMSSW_10_X_VM_docs/README.rst>`_ file of the framework's `github page <https://github.com/vukasinmilosevic/Fiducial_XS/tree/CMSSW_10_X>`_. The following sections dive into more details about each step and new students are highly encouraged to explore this route when first joining the analysis effort.
 
 [TBC]
 ------------------

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
A few changes related to the documentation:

- Created a ReadTheDocs template for the Fiducial XS framework:
  - Updated .gitignore to omit ``docs/_build`` which is to be used only for local testing via i.e. ``make html``

  -  ReadTheDocs page will update with each change and the corresponding badge (displayed in the new ReadMe file) will reflect the status of the latest build.

- Revamped the ReadMe file to use restructured text syntax:
  - Added badges for easy follow up on documentation status and CMSSW version (this one is custom and needs to be updated by us)
  - Separated the running step into two: via script or step-by-step.