### PR TITLE
interpolation module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Run the interpolation step for powheg sample:
 2.2.4 Running the interpolation step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Run the interpolation step for NNLOPS sample. For NNLOPS sample we don't have M124 and M126 MC samples.
-We assume that the the ratio for the acceptance for M125 and M124.38 is same for both NNLOPS and powheg.
+We assume that the the ratio for the acceptance for M125 and M125.38 is same for both NNLOPS and powheg.
 Then, we compute this ratio from powheg sample and get the values for NNLOPS sample.
 
 NOTE: Run this step after the uncertainty step. As this will also update the pdf and QCD scale uncertainty for NNLOPS.

--- a/README.rst
+++ b/README.rst
@@ -83,11 +83,13 @@ Now, all steps can be run using script ``RunEverything.py``. The available optio
 Commands to run: ::
 
 
-  python RunEverything.py -r 1 -s 1 # step-1
-  python RunEverything.py -r 1 -s 2 # step-2
-  python RunEverything.py -r 1 -s 3 # step-3
-  python RunEverything.py -r 1 -s 4 # step-4
-  python RunEverything.py -r 1 -s 5 # step-5
+  python RunEverything.py -r 1 -s 1 # step-1: Compute efficiencies
+  python RunEverything.py -r 1 -s 2 # step-2: collectInputs
+  python RunEverything.py -r 1 -s 3 # step-3: interpolation for powheg sample
+  python RunEverything.py -r 1 -s 4 # step-4: Run uncertainty step
+  python RunEverything.py -r 1 -s 5 # step-5: interpolation for the NNLOPS sample using powheg sample
+  python RunEverything.py -r 1 -s 6 # step-6: Run background template maker
+  python RunEverything.py -r 1 -s 7 # step-7: Final measurement and plotter
 
 
 2.2 Detailed, step-by-step instructions
@@ -110,13 +112,31 @@ Running the plotter: ::
   #skipping for mass4l
   #python -u plot2dsigeffs.py -l -q -b --obsName="pT4l" --obsBins="|0|10|20|30|45|80|120|200|13000|"
 
+2.2.2 Running the interpolation step
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Run the interpolation step for powheg sample:
 
-2.2.2. Running the uncertainties step
+::
+
+  python python/interpolate_differential_full.py --obsName="mass4l" --obsBins="|105.0|140.0|" --year=2018 --debug 0
+
+2.2.3. Running the uncertainties step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
   python -u getUnc_Unc.py --obsName="mass4l" --obsBins="|105.0|140.0|" >& unc_mass4l.log &
 
+2.2.4 Running the interpolation step
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Run the interpolation step for NNLOPS sample. For NNLOPS sample we don't have M124 and M126 MC samples.
+We assume that the the ratio for the acceptance for M125 and M124.38 is same for both NNLOPS and powheg.
+Then, we compute this ratio from powheg sample and get the values for NNLOPS sample.
+
+NOTE: Run this step after the uncertainty step. As this will also update the pdf and QCD scale uncertainty for NNLOPS.
+
+::
+
+  python python/interpolate_differential_full.py --obsName="mass4l" --obsBins="|105.0|140.0|" --year=2018 --debug 0
 
 2.2.3 Running the background template maker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/RunEverything.py
+++ b/RunEverything.py
@@ -35,6 +35,7 @@ parser.add_argument( '-model', dest='modelNames', default="SM_125,SMup_125,SMdn_
                         help='Names of models for unfolding, separated by , (comma) . Default is "SM_125"')
 parser.add_argument( '-p', dest='NtupleDir', default="/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/", help='Path of ntuples')
 parser.add_argument( '-m', dest='HiggsMass', default=125.0, type=float, help='Higgs mass')
+parser.add_argument( '-y', dest='year', default=2018, type=int, help='dataset year')
 parser.add_argument( '-r', dest='RunCommand', default=0, type=int, choices=[0, 1], help="if 1 then it will run the commands else it will just print the commands")
 
 args = parser.parse_args()
@@ -81,6 +82,14 @@ with open(InputYAMLFile, 'r') as ymlfile:
                     if (args.RunCommand): os.system(command)
 
             if (args.step == 3):
+                border_msg("Running Interpolation to get acceptance for MH = 125. 38 GeV")
+                command = 'python python/interpolate_differential_full.py --obsName="{obsName}" --obsBins="{obsBins}" --year={year}'.format(
+                        obsName = obsName, obsBins = obsBin['bins'], year = args.year
+                )
+                print("Command: {}".format(command))
+                if (args.RunCommand): os.system(command)
+
+            if (args.step == 4):
                 border_msg("Running getUnc")
                 # command = 'python -u getUnc_Unc.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" >& log/unc_{obsName}.log &'.format(
                 command = 'python -u getUnc_Unc.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}"'.format(
@@ -89,8 +98,15 @@ with open(InputYAMLFile, 'r') as ymlfile:
                 print("Command: {}".format(command))
                 if (args.RunCommand): os.system(command)
 
+            if (args.step == 5):
+                border_msg("Grab NNLOPS acc & unc for MH = 125.38 GeV using the powheg sample")
+                command = 'python python/interpolate_differential_pred.py --obsName="{obsName}" --obsBins="{obsBins}" --year={year}'.format(
+                        obsName = obsName, obsBins = obsBin['bins'], year = args.year
+                )
+                print("Command: {}".format(command))
+                if (args.RunCommand): os.system(command)
 
-            if (args.step == 4):
+            if (args.step == 6):
                 border_msg("Running Background template maker")
                 # FIXME: Check if we need modelNames in step-4 or not
                 command = 'python -u runHZZFiducialXS.py --dir="{NtupleDir}" --obsName="{obsName}" --obsBins="{obsBins}" --modelNames {modelNames} --redoTemplates --templatesOnly '.format(
@@ -99,7 +115,7 @@ with open(InputYAMLFile, 'r') as ymlfile:
                 print("Command: {}".format(command))
                 if (args.RunCommand): os.system(command)
 
-            if (args.step == 5):
+            if (args.step == 7):
                 border_msg("Running final measurement and plotters")
                 # Copy model from model directory to combine path
                 CMSSW_BASE = os.getenv('CMSSW_BASE')

--- a/python/LoadData.py
+++ b/python/LoadData.py
@@ -17,7 +17,9 @@ border_msg("samples directory: "+dirMC_94)
 SamplesMC_94 = [
 #File missing or needs to be redirected (Vukasin)'GluGluHToZZTo4L_M125_13TeV_powheg2_minloHJ_NNLOPS_JHUgenV702_pythia8.root',   # path needs to be redirected
 ###
+'GluGluHToZZTo4L_M124_2018_slimmed.root',
 'GluGluHToZZTo4L_M125_2018_slimmed.root',
+'GluGluHToZZTo4L_M126_2018_slimmed.root',
 'VBF_HToZZTo4L_M125_2018_slimmed.root',
 'WH_HToZZTo4L_M125_2018_slimmed.root',
 'ZH_HToZZ_4LFilter_M125_2018_slimmed.root',

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -1,3 +1,5 @@
+from inspect import currentframe
+
 def border_msg(msg):
     """Print message inside the border
 
@@ -18,6 +20,10 @@ def fixed_border_msg(msg):
     border = "="*51
     result = border + "\n" + msg + "\n" + border
     print(result)
+
+def get_linenumber():
+    cf = currentframe()
+    return cf.f_back.f_lineno
 
 def processCmd(cmd, lineNumber, quiet = 0):
     """This function is defined for processing of os command

--- a/python/collectInputs.py
+++ b/python/collectInputs.py
@@ -3,6 +3,7 @@ import os
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
+from Utils import *
 
 sys.path.append('./'+datacardInputs)
 
@@ -20,6 +21,7 @@ def collect(obsName):
 	if (obsName=='mass4l'): channels.append('4l')
 
 	for ch in channels:
+		border_msg("module to import: "+'inputs_sig_'+obsName+'_'+ch+".py")
 		_tmp = __import__('inputs_sig_'+obsName+'_'+ch, globals(), locals(), -1)
 
 		acc.update(_tmp.acc); dacc.update(_tmp.dacc);

--- a/python/interpolate_differential_full.py
+++ b/python/interpolate_differential_full.py
@@ -1,7 +1,12 @@
-import sys, os, string, re, pwd, commands, ast, optparse, shlex, time
-import numpy as np
-#import matplotlib.pyplot as plt
+import optparse
+import os
+import sys
+
 from scipy import interpolate
+import matplotlib.pyplot as plt
+
+from Input_Info import datacardInputs
+
 def parseOptions():
 
     global opt, args, runAllSteps
@@ -15,14 +20,14 @@ def parseOptions():
     global opt, args
     (opt, args) = parser.parse_args()
 
-#
-#def f(x):
-def f(x,n,obsName):
-#def f(mass, channel):
-    #obsName='mass4l'
-   # channel='2e2mu'
-    #sys.path.append('./datacardInputs')
-    sys.path.append('./datacardInputs_'+opt.YEAR+'')
+def interpolate_fun(x, nbins, obsName):
+    sys.path.append(datacardInputs)
+
+    x_points = [124, 125, 126]
+    channels=['4mu','2e2mu','4e']
+
+    if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
+
     acceptance={}
     dacceptance={}
     efficiency={}
@@ -32,14 +37,13 @@ def f(x,n,obsName):
     outinratio = {}
     doutinratio = {}
     inc_outfrac = {}
-#    acc_4l = {}
-#    dacc_4l = {}
+    # acc_4l = {}
+    # dacc_4l = {}
     binfrac_wrongfrac = {}
     cfactor = {}
     lambdajesup = {}
     lambdajesdn = {}
-    #_temp = __import__('accUnc_'+obsName, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
-    #_temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac', 'acc_4l','dacc_4l','inc_outfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
+
     _temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac', 'inc_outfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
     acc_ggH_powheg = _temp.acc
     dacc_ggH_powheg = _temp.dacc
@@ -49,24 +53,21 @@ def f(x,n,obsName):
     binfrac_outfrac_ggH_powheg = _temp.binfrac_outfrac
     outinratio_ggH_powheg = _temp.outinratio
     doutinratio_ggH_powheg = _temp.doutinratio
-#    acc_4l_ggH_powheg = _temp.acc_4l 
-#    dacc_4l_ggH_powheg = _temp.dacc_4l 
-    inc_outfrac_ggH_powheg = _temp.inc_outfrac 
-    binfrac_wrongfrac_ggH_powheg = _temp.binfrac_wrongfrac 
-    cfactor_ggH_powheg = _temp.cfactor 
-    lambdajesup_ggH_powheg = _temp.lambdajesup 
-    lambdajesdn_ggH_powheg = _temp.lambdajesdn 
-    x_points = [124, 125, 126]
-    channels=['4mu','2e2mu','4e']
+    # acc_4l_ggH_powheg = _temp.acc_4l
+    # dacc_4l_ggH_powheg = _temp.dacc_4l
+    inc_outfrac_ggH_powheg = _temp.inc_outfrac
+    binfrac_wrongfrac_ggH_powheg = _temp.binfrac_wrongfrac
+    cfactor_ggH_powheg = _temp.cfactor
+    lambdajesup_ggH_powheg = _temp.lambdajesup
+    lambdajesdn_ggH_powheg = _temp.lambdajesdn
 
-    if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
     for channel in channels:
-	for obsBin in range(0,n-1):
-	    for recoBin in range(0,n-1):
-                thread0p='ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
+        for obsBin in range(0, nbins-1):
+            for recoBin in range(0, nbins-1):
                 thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
-                print "thread is       ", thread
-                acceptance[thread]=0.0 
+                print("{:15} : {}".format("thread", thread))
+
+                acceptance[thread]=0.0
                 dacceptance[thread]=0.0
                 efficiency[thread]=0.0
                 defficiency[thread]=0.0
@@ -74,8 +75,8 @@ def f(x,n,obsName):
                 binfrac_outfrac[thread]=0.0
                 outinratio[thread]=0.0
                 doutinratio[thread]=0.0
-#                acc_4l[thread]=0.0
-#                dacc_4l[thread]=0.0
+                #                acc_4l[thread]=0.0
+                #                dacc_4l[thread]=0.0
                 inc_outfrac[thread]=0.0
                 binfrac_wrongfrac[thread]=0.0
                 cfactor[thread]=0.0
@@ -90,73 +91,77 @@ def f(x,n,obsName):
                 binfrac_outfrac_points = [binfrac_outfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_outfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_outfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 outinratio_points = [outinratio_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],outinratio_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],outinratio_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 doutinratio_points = [doutinratio_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],doutinratio_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],doutinratio_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
- #               acc_4l_points = [acc_4l_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_4l_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_4l_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
- #               dacc_4l_points = [dacc_4l_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_4l_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_4l_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                # acc_4l_points = [acc_4l_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_4l_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_4l_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                # dacc_4l_points = [dacc_4l_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_4l_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_4l_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 inc_outfrac_points = [inc_outfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],inc_outfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],inc_outfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 binfrac_wrongfrac_points = [binfrac_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 cfactor_points = [cfactor_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],cfactor_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],cfactor_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 lambdajesup_points = [lambdajesup_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesup_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesup_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 lambdajesdn_points = [lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
 
-                print "obsName is  ..  ", obsName
-                print "channel is ..  ", channel
-                print "acc_points are,,,,,,,,,,,,,,," ,  acc_points
-                print "eff_points are,,,,,,,,,,,,,,," ,  eff_points
+                print("{:15} : {}".format("obsName", obsName))
+                print("{:15} : {}".format("channel", channel))
+                print("{:15} : {}".format("x_points", x_points))
+                print("{:15} : {}".format("acc_points", acc_points))
+                print("{:15} : {}".format("eff_points", eff_points))
+
+                # # if you want to check the interpolate line uncomment below 4 lines
+                # x2_points = x_points
+                # y2 = interpolate.splev(x2_points, tck1)
+                # plt.plot(x_points, acc_points, 'o', x2_points, y2)
+                # plt.show()
 
 
-    #tck = interpolate.splrep(x_points, y_points)
-                tck1 = interpolate.splrep(x_points, acc_points, k=2)
-                tck2 = interpolate.splrep(x_points, dacc_points, k=2)
-                tck3 = interpolate.splrep(x_points, eff_points, k=2)
-                tck4 = interpolate.splrep(x_points, deff_points, k=2)
-                tck5 = interpolate.splrep(x_points, inc_wrongfrac_points, k=2)
-                tck6 = interpolate.splrep(x_points, binfrac_outfrac_points, k=2)
-                tck7 = interpolate.splrep(x_points, outinratio_points, k=2)
-                tck8 = interpolate.splrep(x_points, doutinratio_points, k=2)
-  #              tck9 = interpolate.splrep(x_points, acc_4l_points, k=2)
-  #              tck10 = interpolate.splrep(x_points, dacc_4l_points, k=2)
-                tck11 = interpolate.splrep(x_points, inc_outfrac_points, k=2)
-                tck12 = interpolate.splrep(x_points, binfrac_wrongfrac_points, k=2)
-                tck13 = interpolate.splrep(x_points, cfactor_points, k=2)
-                tck14 = interpolate.splrep(x_points, lambdajesup_points, k=2)
-                tck15 = interpolate.splrep(x_points, lambdajesdn_points, k=2)
+                # tck = interpolate.splrep(x_points, y_points)
+                spl_acc_points  = interpolate.splrep(x_points, acc_points, k=2)
+                spl_dacc_points = interpolate.splrep(x_points, dacc_points, k=2)
+                spl_eff_points = interpolate.splrep(x_points, eff_points, k=2)
+                spl_deff_points = interpolate.splrep(x_points, deff_points, k=2)
+                spl_inc_wrongfrac_points = interpolate.splrep(x_points, inc_wrongfrac_points, k=2)
+                spl_binfrac_outfrac_points = interpolate.splrep(x_points, binfrac_outfrac_points, k=2)
+                spl_outinratio_points = interpolate.splrep(x_points, outinratio_points, k=2)
+                spl_doutinratio_points = interpolate.splrep(x_points, doutinratio_points, k=2)
+                # spl_acc_4l_points = interpolate.splrep(x_points, acc_4l_points, k=2)
+                # spl_dacc_4l_points = interpolate.splrep(x_points, dacc_4l_points, k=2)
+                spl_inc_outfrac_points = interpolate.splrep(x_points, inc_outfrac_points, k=2)
+                spl_binfrac_wrongfrac_points = interpolate.splrep(x_points, binfrac_wrongfrac_points, k=2)
+                spl_cfactor_points = interpolate.splrep(x_points, cfactor_points, k=2)
+                spl_lambdajesup_points = interpolate.splrep(x_points, lambdajesup_points, k=2)
+                spl_lambdajesdn_points = interpolate.splrep(x_points, lambdajesdn_points, k=2)
 
+                acceptance[thread]=float(interpolate.splev(x, spl_acc_points))
+                dacceptance[thread]= float(interpolate.splev(x, spl_dacc_points))
+                efficiency[thread]=float(interpolate.splev(x, spl_eff_points))
+                defficiency[thread]=float(interpolate.splev(x, spl_deff_points))
+                inc_wrongfrac[thread]=float(interpolate.splev(x, spl_inc_wrongfrac_points))
+                binfrac_outfrac[thread]=float(interpolate.splev(x, spl_binfrac_outfrac_points))
+                outinratio[thread]=float(interpolate.splev(x, spl_outinratio_points))
+                doutinratio[thread]=float(interpolate.splev(x, spl_doutinratio_points))
+                # acc_4l[thread]=float(interpolate.splev(x, spl_acc_4l_points))
+                # dacc_4l[thread]=float(interpolate.splev(x, spl_dacc_4l_points))
+                inc_outfrac[thread]= float(interpolate.splev(x, spl_inc_outfrac_points))
+                binfrac_wrongfrac[thread]= float(interpolate.splev(x, spl_binfrac_wrongfrac_points))
+                cfactor[thread]= float(interpolate.splev(x, spl_cfactor_points))
+                lambdajesup[thread]= float(interpolate.splev(x, spl_lambdajesup_points))
+                lambdajesdn[thread]= float(interpolate.splev(x, spl_lambdajesdn_points))
 
-        #thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
-                acceptance[thread]=float(interpolate.splev(x, tck1))
-                dacceptance[thread]= float(interpolate.splev(x, tck2))
-                efficiency[thread]=float(interpolate.splev(x, tck3))
-                defficiency[thread]=float(interpolate.splev(x, tck4))
-                inc_wrongfrac[thread]=float(interpolate.splev(x, tck5))
-                binfrac_outfrac[thread]=float(interpolate.splev(x, tck6))
-                outinratio[thread]=float(interpolate.splev(x, tck7))
-                doutinratio[thread]=float(interpolate.splev(x, tck8))
-   #             acc_4l[thread]=float(interpolate.splev(x, tck9))
-   #             dacc_4l[thread]=float(interpolate.splev(x, tck10))
-                inc_outfrac[thread]= float(interpolate.splev(x, tck11))
-                binfrac_wrongfrac[thread]= float(interpolate.splev(x, tck12))
-                cfactor[thread]= float(interpolate.splev(x, tck13))
-                lambdajesup[thread]= float(interpolate.splev(x, tck14))
-                lambdajesdn[thread]= float(interpolate.splev(x, tck15))
-
-
-# initializing new thread in list
+                # initializing new thread in list
                 acc_ggH_powheg[str(thread)]={}
-	        dacc_ggH_powheg[str(thread)]={}
-	        eff_ggH_powheg[str(thread)]={}
-	        deff_ggH_powheg[str(thread)]={}
-	        inc_wrongfrac_ggH_powheg[str(thread)]={}
-	        binfrac_outfrac_ggH_powheg[str(thread)]={}
-	        outinratio_ggH_powheg[str(thread)]={}
-	        doutinratio_ggH_powheg[str(thread)]={}
-#	        acc_4l_ggH_powheg[str(thread)]={}
-#	        dacc_4l_ggH_powheg[str(thread)]={}
-	        inc_outfrac_ggH_powheg[str(thread)]={}
-	        binfrac_wrongfrac_ggH_powheg[str(thread)]={}
-	        cfactor_ggH_powheg[str(thread)]={}
-	        lambdajesup_ggH_powheg[str(thread)]={}
-	        lambdajesdn_ggH_powheg[str(thread)]={}
-#################################################################
+                dacc_ggH_powheg[str(thread)]={}
+                eff_ggH_powheg[str(thread)]={}
+                deff_ggH_powheg[str(thread)]={}
+                inc_wrongfrac_ggH_powheg[str(thread)]={}
+                binfrac_outfrac_ggH_powheg[str(thread)]={}
+                outinratio_ggH_powheg[str(thread)]={}
+                doutinratio_ggH_powheg[str(thread)]={}
+                #	        acc_4l_ggH_powheg[str(thread)]={}
+                #	        dacc_4l_ggH_powheg[str(thread)]={}
+                inc_outfrac_ggH_powheg[str(thread)]={}
+                binfrac_wrongfrac_ggH_powheg[str(thread)]={}
+                cfactor_ggH_powheg[str(thread)]={}
+                lambdajesup_ggH_powheg[str(thread)]={}
+                lambdajesdn_ggH_powheg[str(thread)]={}
+                #################################################################
                 acc_ggH_powheg.update(acceptance)
                 dacc_ggH_powheg.update(dacceptance)
                 eff_ggH_powheg.update(efficiency)
@@ -165,28 +170,22 @@ def f(x,n,obsName):
                 binfrac_outfrac_ggH_powheg.update(binfrac_outfrac)
                 outinratio_ggH_powheg.update(outinratio)
                 doutinratio_ggH_powheg.update(doutinratio)
- #               acc_4l_ggH_powheg.update(acc_4l)
- #               dacc_4l_ggH_powheg.update(dacc_4l)
+                #               acc_4l_ggH_powheg.update(acc_4l)
+                #               dacc_4l_ggH_powheg.update(dacc_4l)
                 inc_outfrac_ggH_powheg.update(inc_outfrac)
                 binfrac_wrongfrac_ggH_powheg.update(binfrac_wrongfrac)
                 cfactor_ggH_powheg.update(cfactor)
                 lambdajesup_ggH_powheg.update(lambdajesup)
                 lambdajesdn_ggH_powheg.update(lambdajesdn)
-                
-#print "interpol.           acceptance is  ....................", acc_ggH_powheg[str(thread)]#acc_ggH_powheg
-        #print "pdfunc_ggH_powheg                           ",pdfunc_ggH_powheg
+
+                #print "interpol.           acceptance is  ....................", acc_ggH_powheg[str(thread)]#acc_ggH_powheg
+                #print "pdfunc_ggH_powheg                           ",pdfunc_ggH_powheg
                 print "the thread is ...........", thread
                 print "acceptance is.             ", acceptance[thread] #=float(interpolate.splev(x, tck2))
                 print "dacceptance is.             ", dacceptance[thread] #=float(interpolate.splev(x, tck2))
-#            qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcd_uncerDn[thread]
-                #os.system('cp accUnc_'+opt.OBSNAME+'.py accUnc_'+opt.OBSNAME+'_ORIG.py')
-                #os.system('cp inputs_sig_'+opt.OBSNAME+'.py inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
-                #os.system('cp datacardInputs/inputs_sig_'+opt.OBSNAME+'.py datacardInputs/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
-                os.system('cp datacardInputs_'+opt.YEAR+'/inputs_sig_'+opt.OBSNAME+'.py datacardInputs_'+opt.YEAR+'/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
-#            os.system('cp accUnc_mass4l_ORIG.py accUnc_mass4l.py')
-#            with open('accUnc_mass4l.py', 'w') as f:
-                #with open('accUnc_'+obsName+'.py', 'w') as f:
-                with open('datacardInputs_'+opt.YEAR+'/inputs_sig_'+obsName+'.py', 'w') as f:
+                #            qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcd_uncerDn[thread]
+                os.system('cp datacardInputs/inputs_sig_'+opt.OBSNAME+'.py datacardInputs/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
+                with open('datacardInputs/inputs_sig_'+obsName+'.py', 'w') as f:
                     print "going write interpolated values   "
                     f.write('acc = '+str(acc_ggH_powheg)+' \n')
                     f.write('dacc = '+str(dacc_ggH_powheg)+' \n')
@@ -196,8 +195,8 @@ def f(x,n,obsName):
                     f.write('binfrac_outfrac = '+str(binfrac_outfrac_ggH_powheg)+' \n')
                     f.write('outinratio = '+str(outinratio_ggH_powheg)+' \n')
                     f.write('doutinratio = '+str(doutinratio_ggH_powheg)+' \n')
-  #                  f.write('acc_4l = '+str(acc_4l_ggH_powheg)+' \n')
-  #                  f.write('dacc_4l = '+str(dacc_4l_ggH_powheg)+' \n')
+                #                  f.write('acc_4l = '+str(acc_4l_ggH_powheg)+' \n')
+                #                  f.write('dacc_4l = '+str(dacc_4l_ggH_powheg)+' \n')
                     f.write('inc_outfrac = '+str(inc_outfrac_ggH_powheg)+' \n')
                     f.write('binfrac_wrongfrac = '+str(binfrac_wrongfrac_ggH_powheg)+' \n')
                     f.write('cfactor = '+str(cfactor_ggH_powheg)+' \n')
@@ -205,22 +204,12 @@ def f(x,n,obsName):
                     f.write('lambdajesdn = '+str(lambdajesdn_ggH_powheg)+' \n')
 
 
-    return interpolate.splev(x, tck1)
-    return interpolate.splev(x, tck2)
-    return interpolate.splev(x, tck3)
-    return interpolate.splev(x, tck4)
-    return interpolate.splev(x, tck5)
-    return interpolate.splev(x, tck6)
-    return interpolate.splev(x, tck7)
-    return interpolate.splev(x, tck8)
+if __name__ == "__main__":
+    global opt, args
+    parseOptions()
+    observableBins = {0:(opt.OBSBINS.split("|")[1:(len(opt.OBSBINS.split("|"))-1)]),1:['0','inf']}[opt.OBSBINS=='inclusive']
+    nbins = len(observableBins)
 
-global opt, args
-parseOptions()
-observableBins = {0:(opt.OBSBINS.split("|")[1:(len(opt.OBSBINS.split("|"))-1)]),1:['0','inf']}[opt.OBSBINS=='inclusive']
-nbins = len(observableBins)
-obsName = opt.OBSNAME
+    print("Obs Name: {:15}  nBins: {:2}  bins: {}".format(opt.OBSNAME, nbins, observableBins))
 
-#value= f(125.38);
-value= f(125.38,nbins,obsName);
-#value= f(125)
-print ("the value is ", value)
+    interpolate_fun(125.38, nbins, opt.OBSNAME)

--- a/python/interpolate_differential_full.py
+++ b/python/interpolate_differential_full.py
@@ -1,0 +1,226 @@
+import sys, os, string, re, pwd, commands, ast, optparse, shlex, time
+import numpy as np
+#import matplotlib.pyplot as plt
+from scipy import interpolate
+def parseOptions():
+
+    global opt, args, runAllSteps
+
+    usage = ('usage: %prog [options]\n'
+             + '%prog -h for help')
+    parser = optparse.OptionParser(usage)
+    parser.add_option('',   '--obsName',  dest='OBSNAME',  type='string',default='',   help='Name of the observable, supported: "inclusive", "pT4l", "eta4l", "massZ2", "nJets"')
+    parser.add_option('',   '--obsBins',  dest='OBSBINS',  type='string',default='',   help='Bin boundaries for the diff. measurement separated by "|", e.g. as "|0|50|100|", use the defalut if empty string')
+    parser.add_option('',   '--year',  dest='YEAR',  type='string',default='2018',   help='Era to analyze, e.g. 2016, 2017, 2018 or Full ')
+    global opt, args
+    (opt, args) = parser.parse_args()
+
+#
+#def f(x):
+def f(x,n,obsName):
+#def f(mass, channel):
+    #obsName='mass4l'
+   # channel='2e2mu'
+    #sys.path.append('./datacardInputs')
+    sys.path.append('./datacardInputs_'+opt.YEAR+'')
+    acceptance={}
+    dacceptance={}
+    efficiency={}
+    defficiency={}
+    inc_wrongfrac = {}
+    binfrac_outfrac = {}
+    outinratio = {}
+    doutinratio = {}
+    inc_outfrac = {}
+#    acc_4l = {}
+#    dacc_4l = {}
+    binfrac_wrongfrac = {}
+    cfactor = {}
+    lambdajesup = {}
+    lambdajesdn = {}
+    #_temp = __import__('accUnc_'+obsName, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
+    #_temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac', 'acc_4l','dacc_4l','inc_outfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
+    _temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac', 'inc_outfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
+    acc_ggH_powheg = _temp.acc
+    dacc_ggH_powheg = _temp.dacc
+    eff_ggH_powheg = _temp.eff
+    deff_ggH_powheg = _temp.deff
+    inc_wrongfrac_ggH_powheg = _temp.inc_wrongfrac
+    binfrac_outfrac_ggH_powheg = _temp.binfrac_outfrac
+    outinratio_ggH_powheg = _temp.outinratio
+    doutinratio_ggH_powheg = _temp.doutinratio
+#    acc_4l_ggH_powheg = _temp.acc_4l 
+#    dacc_4l_ggH_powheg = _temp.dacc_4l 
+    inc_outfrac_ggH_powheg = _temp.inc_outfrac 
+    binfrac_wrongfrac_ggH_powheg = _temp.binfrac_wrongfrac 
+    cfactor_ggH_powheg = _temp.cfactor 
+    lambdajesup_ggH_powheg = _temp.lambdajesup 
+    lambdajesdn_ggH_powheg = _temp.lambdajesdn 
+    x_points = [124, 125, 126]
+    channels=['4mu','2e2mu','4e']
+
+    if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
+    for channel in channels:
+	for obsBin in range(0,n-1):
+	    for recoBin in range(0,n-1):
+                thread0p='ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
+                thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
+                print "thread is       ", thread
+                acceptance[thread]=0.0 
+                dacceptance[thread]=0.0
+                efficiency[thread]=0.0
+                defficiency[thread]=0.0
+                inc_wrongfrac[thread]=0.0
+                binfrac_outfrac[thread]=0.0
+                outinratio[thread]=0.0
+                doutinratio[thread]=0.0
+#                acc_4l[thread]=0.0
+#                dacc_4l[thread]=0.0
+                inc_outfrac[thread]=0.0
+                binfrac_wrongfrac[thread]=0.0
+                cfactor[thread]=0.0
+                lambdajesup[thread]=0.0
+                lambdajesdn[thread]=0.0
+
+                acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                dacc_points = [dacc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                eff_points = [eff_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],eff_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],eff_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                deff_points = [deff_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],deff_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],deff_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                inc_wrongfrac_points = [inc_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],inc_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],inc_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                binfrac_outfrac_points = [binfrac_outfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_outfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_outfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                outinratio_points = [outinratio_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],outinratio_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],outinratio_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                doutinratio_points = [doutinratio_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],doutinratio_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],doutinratio_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+ #               acc_4l_points = [acc_4l_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_4l_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_4l_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+ #               dacc_4l_points = [dacc_4l_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_4l_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_4l_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                inc_outfrac_points = [inc_outfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],inc_outfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],inc_outfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                binfrac_wrongfrac_points = [binfrac_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],binfrac_wrongfrac_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                cfactor_points = [cfactor_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],cfactor_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],cfactor_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                lambdajesup_points = [lambdajesup_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesup_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesup_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+                lambdajesdn_points = [lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
+
+                print "obsName is  ..  ", obsName
+                print "channel is ..  ", channel
+                print "acc_points are,,,,,,,,,,,,,,," ,  acc_points
+                print "eff_points are,,,,,,,,,,,,,,," ,  eff_points
+
+
+    #tck = interpolate.splrep(x_points, y_points)
+                tck1 = interpolate.splrep(x_points, acc_points, k=2)
+                tck2 = interpolate.splrep(x_points, dacc_points, k=2)
+                tck3 = interpolate.splrep(x_points, eff_points, k=2)
+                tck4 = interpolate.splrep(x_points, deff_points, k=2)
+                tck5 = interpolate.splrep(x_points, inc_wrongfrac_points, k=2)
+                tck6 = interpolate.splrep(x_points, binfrac_outfrac_points, k=2)
+                tck7 = interpolate.splrep(x_points, outinratio_points, k=2)
+                tck8 = interpolate.splrep(x_points, doutinratio_points, k=2)
+  #              tck9 = interpolate.splrep(x_points, acc_4l_points, k=2)
+  #              tck10 = interpolate.splrep(x_points, dacc_4l_points, k=2)
+                tck11 = interpolate.splrep(x_points, inc_outfrac_points, k=2)
+                tck12 = interpolate.splrep(x_points, binfrac_wrongfrac_points, k=2)
+                tck13 = interpolate.splrep(x_points, cfactor_points, k=2)
+                tck14 = interpolate.splrep(x_points, lambdajesup_points, k=2)
+                tck15 = interpolate.splrep(x_points, lambdajesdn_points, k=2)
+
+
+        #thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+                acceptance[thread]=float(interpolate.splev(x, tck1))
+                dacceptance[thread]= float(interpolate.splev(x, tck2))
+                efficiency[thread]=float(interpolate.splev(x, tck3))
+                defficiency[thread]=float(interpolate.splev(x, tck4))
+                inc_wrongfrac[thread]=float(interpolate.splev(x, tck5))
+                binfrac_outfrac[thread]=float(interpolate.splev(x, tck6))
+                outinratio[thread]=float(interpolate.splev(x, tck7))
+                doutinratio[thread]=float(interpolate.splev(x, tck8))
+   #             acc_4l[thread]=float(interpolate.splev(x, tck9))
+   #             dacc_4l[thread]=float(interpolate.splev(x, tck10))
+                inc_outfrac[thread]= float(interpolate.splev(x, tck11))
+                binfrac_wrongfrac[thread]= float(interpolate.splev(x, tck12))
+                cfactor[thread]= float(interpolate.splev(x, tck13))
+                lambdajesup[thread]= float(interpolate.splev(x, tck14))
+                lambdajesdn[thread]= float(interpolate.splev(x, tck15))
+
+
+# initializing new thread in list
+                acc_ggH_powheg[str(thread)]={}
+	        dacc_ggH_powheg[str(thread)]={}
+	        eff_ggH_powheg[str(thread)]={}
+	        deff_ggH_powheg[str(thread)]={}
+	        inc_wrongfrac_ggH_powheg[str(thread)]={}
+	        binfrac_outfrac_ggH_powheg[str(thread)]={}
+	        outinratio_ggH_powheg[str(thread)]={}
+	        doutinratio_ggH_powheg[str(thread)]={}
+#	        acc_4l_ggH_powheg[str(thread)]={}
+#	        dacc_4l_ggH_powheg[str(thread)]={}
+	        inc_outfrac_ggH_powheg[str(thread)]={}
+	        binfrac_wrongfrac_ggH_powheg[str(thread)]={}
+	        cfactor_ggH_powheg[str(thread)]={}
+	        lambdajesup_ggH_powheg[str(thread)]={}
+	        lambdajesdn_ggH_powheg[str(thread)]={}
+#################################################################
+                acc_ggH_powheg.update(acceptance)
+                dacc_ggH_powheg.update(dacceptance)
+                eff_ggH_powheg.update(efficiency)
+                deff_ggH_powheg.update(defficiency)
+                inc_wrongfrac_ggH_powheg.update(inc_wrongfrac)
+                binfrac_outfrac_ggH_powheg.update(binfrac_outfrac)
+                outinratio_ggH_powheg.update(outinratio)
+                doutinratio_ggH_powheg.update(doutinratio)
+ #               acc_4l_ggH_powheg.update(acc_4l)
+ #               dacc_4l_ggH_powheg.update(dacc_4l)
+                inc_outfrac_ggH_powheg.update(inc_outfrac)
+                binfrac_wrongfrac_ggH_powheg.update(binfrac_wrongfrac)
+                cfactor_ggH_powheg.update(cfactor)
+                lambdajesup_ggH_powheg.update(lambdajesup)
+                lambdajesdn_ggH_powheg.update(lambdajesdn)
+                
+#print "interpol.           acceptance is  ....................", acc_ggH_powheg[str(thread)]#acc_ggH_powheg
+        #print "pdfunc_ggH_powheg                           ",pdfunc_ggH_powheg
+                print "the thread is ...........", thread
+                print "acceptance is.             ", acceptance[thread] #=float(interpolate.splev(x, tck2))
+                print "dacceptance is.             ", dacceptance[thread] #=float(interpolate.splev(x, tck2))
+#            qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcd_uncerDn[thread]
+                #os.system('cp accUnc_'+opt.OBSNAME+'.py accUnc_'+opt.OBSNAME+'_ORIG.py')
+                #os.system('cp inputs_sig_'+opt.OBSNAME+'.py inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
+                #os.system('cp datacardInputs/inputs_sig_'+opt.OBSNAME+'.py datacardInputs/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
+                os.system('cp datacardInputs_'+opt.YEAR+'/inputs_sig_'+opt.OBSNAME+'.py datacardInputs_'+opt.YEAR+'/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
+#            os.system('cp accUnc_mass4l_ORIG.py accUnc_mass4l.py')
+#            with open('accUnc_mass4l.py', 'w') as f:
+                #with open('accUnc_'+obsName+'.py', 'w') as f:
+                with open('datacardInputs_'+opt.YEAR+'/inputs_sig_'+obsName+'.py', 'w') as f:
+                    print "going write interpolated values   "
+                    f.write('acc = '+str(acc_ggH_powheg)+' \n')
+                    f.write('dacc = '+str(dacc_ggH_powheg)+' \n')
+                    f.write('eff = '+str(eff_ggH_powheg)+' \n')
+                    f.write('deff = '+str(deff_ggH_powheg)+' \n')
+                    f.write('inc_wrongfrac = '+str(inc_wrongfrac_ggH_powheg)+' \n')
+                    f.write('binfrac_outfrac = '+str(binfrac_outfrac_ggH_powheg)+' \n')
+                    f.write('outinratio = '+str(outinratio_ggH_powheg)+' \n')
+                    f.write('doutinratio = '+str(doutinratio_ggH_powheg)+' \n')
+  #                  f.write('acc_4l = '+str(acc_4l_ggH_powheg)+' \n')
+  #                  f.write('dacc_4l = '+str(dacc_4l_ggH_powheg)+' \n')
+                    f.write('inc_outfrac = '+str(inc_outfrac_ggH_powheg)+' \n')
+                    f.write('binfrac_wrongfrac = '+str(binfrac_wrongfrac_ggH_powheg)+' \n')
+                    f.write('cfactor = '+str(cfactor_ggH_powheg)+' \n')
+                    f.write('lambdajesup = '+str(lambdajesup_ggH_powheg)+' \n')
+                    f.write('lambdajesdn = '+str(lambdajesdn_ggH_powheg)+' \n')
+
+
+    return interpolate.splev(x, tck1)
+    return interpolate.splev(x, tck2)
+    return interpolate.splev(x, tck3)
+    return interpolate.splev(x, tck4)
+    return interpolate.splev(x, tck5)
+    return interpolate.splev(x, tck6)
+    return interpolate.splev(x, tck7)
+    return interpolate.splev(x, tck8)
+
+global opt, args
+parseOptions()
+observableBins = {0:(opt.OBSBINS.split("|")[1:(len(opt.OBSBINS.split("|"))-1)]),1:['0','inf']}[opt.OBSBINS=='inclusive']
+nbins = len(observableBins)
+obsName = opt.OBSNAME
+
+#value= f(125.38);
+value= f(125.38,nbins,obsName);
+#value= f(125)
+print ("the value is ", value)

--- a/python/interpolate_differential_full.py
+++ b/python/interpolate_differential_full.py
@@ -6,6 +6,7 @@ from scipy import interpolate
 import matplotlib.pyplot as plt
 
 from Input_Info import datacardInputs
+from Utils import *
 
 def parseOptions():
 
@@ -17,10 +18,12 @@ def parseOptions():
     parser.add_option('',   '--obsName',  dest='OBSNAME',  type='string',default='',   help='Name of the observable, supported: "inclusive", "pT4l", "eta4l", "massZ2", "nJets"')
     parser.add_option('',   '--obsBins',  dest='OBSBINS',  type='string',default='',   help='Bin boundaries for the diff. measurement separated by "|", e.g. as "|0|50|100|", use the defalut if empty string')
     parser.add_option('',   '--year',  dest='YEAR',  type='string',default='2018',   help='Era to analyze, e.g. 2016, 2017, 2018 or Full ')
+    parser.add_option('',   '--debug',  dest='DEBUG',  type='int',default=0,   help='0 if debug false, else debug True')
     global opt, args
     (opt, args) = parser.parse_args()
 
-def interpolate_fun(x, nbins, obsName):
+def interpolate_fun(x, nbins, obsName, DEBUG = 0):
+    border_msg("Start of module `interpolate_fun`")
     sys.path.append(datacardInputs)
 
     x_points = [124, 125, 126]
@@ -29,6 +32,7 @@ def interpolate_fun(x, nbins, obsName):
     if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
 
     acceptance={}
+    if (DEBUG): print("===>Line#{}:  acceptance: {}".format(get_linenumber(), acceptance))
     dacceptance={}
     efficiency={}
     defficiency={}
@@ -46,6 +50,7 @@ def interpolate_fun(x, nbins, obsName):
 
     _temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac', 'inc_outfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
     acc_ggH_powheg = _temp.acc
+    if (DEBUG): print("===>Line#{}:  acc_ggH_powheg: {}".format(get_linenumber(), acc_ggH_powheg))
     dacc_ggH_powheg = _temp.dacc
     eff_ggH_powheg = _temp.eff
     deff_ggH_powheg = _temp.deff
@@ -64,25 +69,14 @@ def interpolate_fun(x, nbins, obsName):
     for channel in channels:
         for obsBin in range(0, nbins-1):
             for recoBin in range(0, nbins-1):
+                border_msg("Channel: {:5} obsBin: {:3}  recoBin: {}".format(channel, obsBin, recoBin))
                 thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
-                print("{:15} : {}".format("thread", thread))
+                print("=== ===>{:15} : {}".format("obsName", obsName))
+                print("=== ===>{:15} : {}".format("channel", channel))
+                print("=== ===>{:15} : {}".format("x_points", x_points))
+                print("=== ===>{:15} : {}".format("dict key", thread))
 
-                acceptance[thread]=0.0
-                dacceptance[thread]=0.0
-                efficiency[thread]=0.0
-                defficiency[thread]=0.0
-                inc_wrongfrac[thread]=0.0
-                binfrac_outfrac[thread]=0.0
-                outinratio[thread]=0.0
-                doutinratio[thread]=0.0
-                #                acc_4l[thread]=0.0
-                #                dacc_4l[thread]=0.0
-                inc_outfrac[thread]=0.0
-                binfrac_wrongfrac[thread]=0.0
-                cfactor[thread]=0.0
-                lambdajesup[thread]=0.0
-                lambdajesdn[thread]=0.0
-
+                # INFO: Step: 1: Grab info from inputs_sig_*.py and get an array for three different mass points [124, 125, 126] using corresponding acc, eff, etc.
                 acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 dacc_points = [dacc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],dacc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 eff_points = [eff_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],eff_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],eff_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
@@ -99,19 +93,10 @@ def interpolate_fun(x, nbins, obsName):
                 lambdajesup_points = [lambdajesup_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesup_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesup_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
                 lambdajesdn_points = [lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],lambdajesdn_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
 
-                print("{:15} : {}".format("obsName", obsName))
-                print("{:15} : {}".format("channel", channel))
-                print("{:15} : {}".format("x_points", x_points))
-                print("{:15} : {}".format("acc_points", acc_points))
-                print("{:15} : {}".format("eff_points", eff_points))
+                print("=== ===>{:15} : {}".format("acc_points", acc_points))
+                print("=== ===>{:15} : {}".format("eff_points", eff_points))
 
-                # # if you want to check the interpolate line uncomment below 4 lines
-                # x2_points = x_points
-                # y2 = interpolate.splev(x2_points, tck1)
-                # plt.plot(x_points, acc_points, 'o', x2_points, y2)
-                # plt.show()
-
-
+                # INFO: Step - 2: Interpolate the line
                 # tck = interpolate.splrep(x_points, y_points)
                 spl_acc_points  = interpolate.splrep(x_points, acc_points, k=2)
                 spl_dacc_points = interpolate.splrep(x_points, dacc_points, k=2)
@@ -129,6 +114,7 @@ def interpolate_fun(x, nbins, obsName):
                 spl_lambdajesup_points = interpolate.splrep(x_points, lambdajesup_points, k=2)
                 spl_lambdajesdn_points = interpolate.splrep(x_points, lambdajesdn_points, k=2)
 
+                # INFO: Step - 3: Get the value corresponding to "x" based on the interpolation line done above
                 acceptance[thread]=float(interpolate.splev(x, spl_acc_points))
                 dacceptance[thread]= float(interpolate.splev(x, spl_dacc_points))
                 efficiency[thread]=float(interpolate.splev(x, spl_eff_points))
@@ -145,23 +131,10 @@ def interpolate_fun(x, nbins, obsName):
                 lambdajesup[thread]= float(interpolate.splev(x, spl_lambdajesup_points))
                 lambdajesdn[thread]= float(interpolate.splev(x, spl_lambdajesdn_points))
 
-                # initializing new thread in list
-                acc_ggH_powheg[str(thread)]={}
-                dacc_ggH_powheg[str(thread)]={}
-                eff_ggH_powheg[str(thread)]={}
-                deff_ggH_powheg[str(thread)]={}
-                inc_wrongfrac_ggH_powheg[str(thread)]={}
-                binfrac_outfrac_ggH_powheg[str(thread)]={}
-                outinratio_ggH_powheg[str(thread)]={}
-                doutinratio_ggH_powheg[str(thread)]={}
-                #	        acc_4l_ggH_powheg[str(thread)]={}
-                #	        dacc_4l_ggH_powheg[str(thread)]={}
-                inc_outfrac_ggH_powheg[str(thread)]={}
-                binfrac_wrongfrac_ggH_powheg[str(thread)]={}
-                cfactor_ggH_powheg[str(thread)]={}
-                lambdajesup_ggH_powheg[str(thread)]={}
-                lambdajesdn_ggH_powheg[str(thread)]={}
+                print("=== ===>{:15} : {}".format("acceptance", acceptance))
+
                 #################################################################
+                # INFO: Step - 4: Update the original dict
                 acc_ggH_powheg.update(acceptance)
                 dacc_ggH_powheg.update(dacceptance)
                 eff_ggH_powheg.update(efficiency)
@@ -170,38 +143,33 @@ def interpolate_fun(x, nbins, obsName):
                 binfrac_outfrac_ggH_powheg.update(binfrac_outfrac)
                 outinratio_ggH_powheg.update(outinratio)
                 doutinratio_ggH_powheg.update(doutinratio)
-                #               acc_4l_ggH_powheg.update(acc_4l)
-                #               dacc_4l_ggH_powheg.update(dacc_4l)
+                # acc_4l_ggH_powheg.update(acc_4l)
+                # dacc_4l_ggH_powheg.update(dacc_4l)
                 inc_outfrac_ggH_powheg.update(inc_outfrac)
                 binfrac_wrongfrac_ggH_powheg.update(binfrac_wrongfrac)
                 cfactor_ggH_powheg.update(cfactor)
                 lambdajesup_ggH_powheg.update(lambdajesup)
                 lambdajesdn_ggH_powheg.update(lambdajesdn)
+                if (DEBUG): print("=== ===>{:15} : {}".format("acc_ggH_powheg", acc_ggH_powheg))
 
-                #print "interpol.           acceptance is  ....................", acc_ggH_powheg[str(thread)]#acc_ggH_powheg
-                #print "pdfunc_ggH_powheg                           ",pdfunc_ggH_powheg
-                print "the thread is ...........", thread
-                print "acceptance is.             ", acceptance[thread] #=float(interpolate.splev(x, tck2))
-                print "dacceptance is.             ", dacceptance[thread] #=float(interpolate.splev(x, tck2))
-                #            qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcd_uncerDn[thread]
-                os.system('cp datacardInputs/inputs_sig_'+opt.OBSNAME+'.py datacardInputs/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
-                with open('datacardInputs/inputs_sig_'+obsName+'.py', 'w') as f:
-                    print "going write interpolated values   "
-                    f.write('acc = '+str(acc_ggH_powheg)+' \n')
-                    f.write('dacc = '+str(dacc_ggH_powheg)+' \n')
-                    f.write('eff = '+str(eff_ggH_powheg)+' \n')
-                    f.write('deff = '+str(deff_ggH_powheg)+' \n')
-                    f.write('inc_wrongfrac = '+str(inc_wrongfrac_ggH_powheg)+' \n')
-                    f.write('binfrac_outfrac = '+str(binfrac_outfrac_ggH_powheg)+' \n')
-                    f.write('outinratio = '+str(outinratio_ggH_powheg)+' \n')
-                    f.write('doutinratio = '+str(doutinratio_ggH_powheg)+' \n')
-                #                  f.write('acc_4l = '+str(acc_4l_ggH_powheg)+' \n')
-                #                  f.write('dacc_4l = '+str(dacc_4l_ggH_powheg)+' \n')
-                    f.write('inc_outfrac = '+str(inc_outfrac_ggH_powheg)+' \n')
-                    f.write('binfrac_wrongfrac = '+str(binfrac_wrongfrac_ggH_powheg)+' \n')
-                    f.write('cfactor = '+str(cfactor_ggH_powheg)+' \n')
-                    f.write('lambdajesup = '+str(lambdajesup_ggH_powheg)+' \n')
-                    f.write('lambdajesdn = '+str(lambdajesdn_ggH_powheg)+' \n')
+    os.system('cp '+datacardInputs+'/inputs_sig_'+opt.OBSNAME+'.py '+datacardInputs+'/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
+    with open(datacardInputs+'/inputs_sig_'+obsName+'.py', 'w') as f:
+        print("going write interpolated values   ")
+        f.write('acc = '+str(acc_ggH_powheg)+' \n')
+        f.write('dacc = '+str(dacc_ggH_powheg)+' \n')
+        f.write('eff = '+str(eff_ggH_powheg)+' \n')
+        f.write('deff = '+str(deff_ggH_powheg)+' \n')
+        f.write('inc_wrongfrac = '+str(inc_wrongfrac_ggH_powheg)+' \n')
+        f.write('binfrac_outfrac = '+str(binfrac_outfrac_ggH_powheg)+' \n')
+        f.write('outinratio = '+str(outinratio_ggH_powheg)+' \n')
+        f.write('doutinratio = '+str(doutinratio_ggH_powheg)+' \n')
+        # f.write('acc_4l = '+str(acc_4l_ggH_powheg)+' \n')
+        # f.write('dacc_4l = '+str(dacc_4l_ggH_powheg)+' \n')
+        f.write('inc_outfrac = '+str(inc_outfrac_ggH_powheg)+' \n')
+        f.write('binfrac_wrongfrac = '+str(binfrac_wrongfrac_ggH_powheg)+' \n')
+        f.write('cfactor = '+str(cfactor_ggH_powheg)+' \n')
+        f.write('lambdajesup = '+str(lambdajesup_ggH_powheg)+' \n')
+        f.write('lambdajesdn = '+str(lambdajesdn_ggH_powheg)+' \n')
 
 
 if __name__ == "__main__":
@@ -212,4 +180,5 @@ if __name__ == "__main__":
 
     print("Obs Name: {:15}  nBins: {:2}  bins: {}".format(opt.OBSNAME, nbins, observableBins))
 
-    interpolate_fun(125.38, nbins, opt.OBSNAME)
+    interpolate_fun(125.38, nbins, opt.OBSNAME, opt.DEBUG)
+    print("Interpolation completed... :) ")

--- a/python/interpolate_differential_full.py
+++ b/python/interpolate_differential_full.py
@@ -22,8 +22,8 @@ def parseOptions():
     global opt, args
     (opt, args) = parser.parse_args()
 
-def interpolate_fun(x, nbins, obsName, DEBUG = 0):
-    border_msg("Start of module `interpolate_fun`")
+def interpolate_full(x, nbins, obsName, DEBUG = 0):
+    border_msg("Start of module `interpolate_full`")
     sys.path.append(datacardInputs)
 
     x_points = [124, 125, 126]
@@ -32,7 +32,6 @@ def interpolate_fun(x, nbins, obsName, DEBUG = 0):
     if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
 
     acceptance={}
-    if (DEBUG): print("===>Line#{}:  acceptance: {}".format(get_linenumber(), acceptance))
     dacceptance={}
     efficiency={}
     defficiency={}
@@ -47,10 +46,10 @@ def interpolate_fun(x, nbins, obsName, DEBUG = 0):
     cfactor = {}
     lambdajesup = {}
     lambdajesdn = {}
+    if (DEBUG): print("===>Line#{}:  acceptance: {}".format(get_linenumber(), acceptance))
 
     _temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac', 'inc_outfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
     acc_ggH_powheg = _temp.acc
-    if (DEBUG): print("===>Line#{}:  acc_ggH_powheg: {}".format(get_linenumber(), acc_ggH_powheg))
     dacc_ggH_powheg = _temp.dacc
     eff_ggH_powheg = _temp.eff
     deff_ggH_powheg = _temp.deff
@@ -65,16 +64,15 @@ def interpolate_fun(x, nbins, obsName, DEBUG = 0):
     cfactor_ggH_powheg = _temp.cfactor
     lambdajesup_ggH_powheg = _temp.lambdajesup
     lambdajesdn_ggH_powheg = _temp.lambdajesdn
+    if (DEBUG): print("===>Line#{}:  acc_ggH_powheg: {}".format(get_linenumber(), acc_ggH_powheg))
 
     for channel in channels:
         for obsBin in range(0, nbins-1):
             for recoBin in range(0, nbins-1):
-                border_msg("Channel: {:5} obsBin: {:3}  recoBin: {}".format(channel, obsBin, recoBin))
-                thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
-                print("=== ===>{:15} : {}".format("obsName", obsName))
-                print("=== ===>{:15} : {}".format("channel", channel))
-                print("=== ===>{:15} : {}".format("x_points", x_points))
-                print("=== ===>{:15} : {}".format("dict key", thread))
+                border_msg("obsName: {:11} Channel: {:5} obsBin: {:3}  recoBin: {}".format(obsName, channel, obsBin, recoBin))
+
+                key_powheg_MX = 'ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)
+                print("=== ===>{:15} : {}".format("dict key", key_powheg_MX))
 
                 # INFO: Step: 1: Grab info from inputs_sig_*.py and get an array for three different mass points [124, 125, 126] using corresponding acc, eff, etc.
                 acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)+'_recobin'+str(recoBin)]]
@@ -115,21 +113,21 @@ def interpolate_fun(x, nbins, obsName, DEBUG = 0):
                 spl_lambdajesdn_points = interpolate.splrep(x_points, lambdajesdn_points, k=2)
 
                 # INFO: Step - 3: Get the value corresponding to "x" based on the interpolation line done above
-                acceptance[thread]=float(interpolate.splev(x, spl_acc_points))
-                dacceptance[thread]= float(interpolate.splev(x, spl_dacc_points))
-                efficiency[thread]=float(interpolate.splev(x, spl_eff_points))
-                defficiency[thread]=float(interpolate.splev(x, spl_deff_points))
-                inc_wrongfrac[thread]=float(interpolate.splev(x, spl_inc_wrongfrac_points))
-                binfrac_outfrac[thread]=float(interpolate.splev(x, spl_binfrac_outfrac_points))
-                outinratio[thread]=float(interpolate.splev(x, spl_outinratio_points))
-                doutinratio[thread]=float(interpolate.splev(x, spl_doutinratio_points))
-                # acc_4l[thread]=float(interpolate.splev(x, spl_acc_4l_points))
-                # dacc_4l[thread]=float(interpolate.splev(x, spl_dacc_4l_points))
-                inc_outfrac[thread]= float(interpolate.splev(x, spl_inc_outfrac_points))
-                binfrac_wrongfrac[thread]= float(interpolate.splev(x, spl_binfrac_wrongfrac_points))
-                cfactor[thread]= float(interpolate.splev(x, spl_cfactor_points))
-                lambdajesup[thread]= float(interpolate.splev(x, spl_lambdajesup_points))
-                lambdajesdn[thread]= float(interpolate.splev(x, spl_lambdajesdn_points))
+                acceptance[key_powheg_MX]=float(interpolate.splev(x, spl_acc_points))
+                dacceptance[key_powheg_MX]= float(interpolate.splev(x, spl_dacc_points))
+                efficiency[key_powheg_MX]=float(interpolate.splev(x, spl_eff_points))
+                defficiency[key_powheg_MX]=float(interpolate.splev(x, spl_deff_points))
+                inc_wrongfrac[key_powheg_MX]=float(interpolate.splev(x, spl_inc_wrongfrac_points))
+                binfrac_outfrac[key_powheg_MX]=float(interpolate.splev(x, spl_binfrac_outfrac_points))
+                outinratio[key_powheg_MX]=float(interpolate.splev(x, spl_outinratio_points))
+                doutinratio[key_powheg_MX]=float(interpolate.splev(x, spl_doutinratio_points))
+                # acc_4l[key_powheg_MX]=float(interpolate.splev(x, spl_acc_4l_points))
+                # dacc_4l[key_powheg_MX]=float(interpolate.splev(x, spl_dacc_4l_points))
+                inc_outfrac[key_powheg_MX]= float(interpolate.splev(x, spl_inc_outfrac_points))
+                binfrac_wrongfrac[key_powheg_MX]= float(interpolate.splev(x, spl_binfrac_wrongfrac_points))
+                cfactor[key_powheg_MX]= float(interpolate.splev(x, spl_cfactor_points))
+                lambdajesup[key_powheg_MX]= float(interpolate.splev(x, spl_lambdajesup_points))
+                lambdajesdn[key_powheg_MX]= float(interpolate.splev(x, spl_lambdajesdn_points))
 
                 print("=== ===>{:15} : {}".format("acceptance", acceptance))
 
@@ -152,9 +150,11 @@ def interpolate_fun(x, nbins, obsName, DEBUG = 0):
                 lambdajesdn_ggH_powheg.update(lambdajesdn)
                 if (DEBUG): print("=== ===>{:15} : {}".format("acc_ggH_powheg", acc_ggH_powheg))
 
-    os.system('cp '+datacardInputs+'/inputs_sig_'+opt.OBSNAME+'.py '+datacardInputs+'/inputs_sig_'+opt.OBSNAME+'_beforeInterpolation.py')
-    with open(datacardInputs+'/inputs_sig_'+obsName+'.py', 'w') as f:
-        print("going write interpolated values   ")
+    OutputDictFileName = datacardInputs+'/inputs_sig_'+obsName+'.py'
+    os.system('cp ' + OutputDictFileName + " " + OutputDictFileName.replace('.py','_beforeInterpolation.py'))
+
+    with open( OutputDictFileName, 'w') as f:
+        print("going write interpolated values  in  "+OutputDictFileName)
         f.write('acc = '+str(acc_ggH_powheg)+' \n')
         f.write('dacc = '+str(dacc_ggH_powheg)+' \n')
         f.write('eff = '+str(eff_ggH_powheg)+' \n')
@@ -180,5 +180,5 @@ if __name__ == "__main__":
 
     print("Obs Name: {:15}  nBins: {:2}  bins: {}".format(opt.OBSNAME, nbins, observableBins))
 
-    interpolate_fun(125.38, nbins, opt.OBSNAME, opt.DEBUG)
+    interpolate_full(125.38, nbins, opt.OBSNAME, opt.DEBUG)
     print("Interpolation completed... :) ")

--- a/python/interpolate_differential_pred.py
+++ b/python/interpolate_differential_pred.py
@@ -1,0 +1,165 @@
+import sys, os, string, re, pwd, commands, ast, optparse, shlex, time
+import numpy as np
+#import matplotlib.pyplot as plt
+from scipy import interpolate
+def parseOptions():
+
+    global opt, args, runAllSteps
+
+    usage = ('usage: %prog [options]\n'
+             + '%prog -h for help')
+    parser = optparse.OptionParser(usage)
+    parser.add_option('',   '--obsName',  dest='OBSNAME',  type='string',default='',   help='Name of the observable, supported: "inclusive", "pT4l", "eta4l", "massZ2", "nJets"')
+    parser.add_option('',   '--obsBins',  dest='OBSBINS',  type='string',default='',   help='Bin boundaries for the diff. measurement separated by "|", e.g. as "|0|50|100|", use the defalut if empty string')
+    parser.add_option('',   '--year',  dest='YEAR',  type='string',default='2018',   help='Era to analyze, e.g. 2016, 2017, 2018 or Full ')
+    global opt, args
+    (opt, args) = parser.parse_args()
+
+#
+#def f(x):
+def f(x,n,obsName):
+#def f(mass, channel):
+    #obsName='mass4l'
+   # channel='2e2mu'
+    acceptance={}
+#    pdfunc={}
+    pdf_uncerUp={}
+    pdf_uncerDn={}
+    qcd_uncerUp={}
+    qcd_uncerDn={}
+    qcdunc={}
+    #_temp = __import__('accUnc_'+obsName, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
+    #_temp = __import__('accUnc_'+obsName'_2018', globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
+    _temp = __import__('accUnc_'+obsName+'_'+opt.YEAR, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
+    acc_ggH_powheg = _temp.acc
+    print "acc_ggH_powheg", acc_ggH_powheg
+    pdfunc_ggH_powheg = _temp.pdfUncert
+    qcdunc_ggH_powheg = _temp.qcdUncert
+# ggH_powheg_JHUgen_126_2e2mu_'+obsName+'_genbin0
+#from scipy import interpolate
+#
+#def f(x):
+    #x_points = [ 0, 1, 2, 3, 4, 5]
+    x_points = [124, 125, 126]
+    #x_points = [124, 125, 126,130]
+    channels=['4mu','2e2mu','4e']
+
+    if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
+    #y_points = [12,14,22,39,58,77]
+    #y_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_2e2mu_'+obsName+'_genbin0'],acc_ggH_powheg['ggH_powheg_JHUgen_125_2e2mu_'+obsName+'_genbin0'],acc_ggH_powheg['ggH_powheg_JHUgen_126_2e2mu_'+obsName+'_genbin0']]   #  [12,14,22,39,58,77]
+    for channel in channels:
+	for obsBin in range(0,n-1):
+        #thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin0'
+            thread0p='ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            thread2='ggH_NNLOPS_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            thread0n='ggH_NNLOPS_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            print "thread is       ", thread
+            acceptance[thread]=0.0
+            pdf_uncerUp[thread]=0.0
+            pdf_uncerDn[thread]=0.0
+            qcd_uncerUp[thread]=0.0
+            qcd_uncerDn[thread]=0.0
+            #acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]]   #  [12,14,22,39,58,77]
+            acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]]   #  [12,14,22,39,58,77]
+	    #pdf_points_uncerUp = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
+	    pdf_points_uncerUp = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
+	    #pdf_points_uncerDn = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']] 
+	    pdf_points_uncerDn = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']] 
+            #qcd_points_uncerUp = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
+            qcd_points_uncerUp = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
+            #qcd_points_uncerDn = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']]   #  [12,14,22,39,58,77]
+            qcd_points_uncerDn = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']]   #  [12,14,22,39,58,77]
+            print "obsName is  ..  ", obsName
+            print "channel is ..  ", channel
+            print "acc_points are,,,,,,,,,,,,,,," ,  acc_points
+            print "pdf_points_uncerUp are,,,,,,,,,,,,,,," ,  pdf_points_uncerUp
+            print "pdf_points_uncerDn are,,,,,,,,,,,,,,," ,  pdf_points_uncerDn
+            print "qcd_points_uncerUp are,,,,,,,,,,,,,,," ,  qcd_points_uncerUp
+            print "qcd_points_uncerDn are,,,,,,,,,,,,,,," ,  qcd_points_uncerDn
+
+
+    #tck = interpolate.splrep(x_points, y_points)
+            tck1 = interpolate.splrep(x_points, acc_points, k=2)
+            tck2 = interpolate.splrep(x_points, pdf_points_uncerUp, k=2)
+            tck3 = interpolate.splrep(x_points, pdf_points_uncerDn, k=2)
+            tck4 = interpolate.splrep(x_points, qcd_points_uncerUp, k=2)
+            tck5 = interpolate.splrep(x_points, qcd_points_uncerDn, k=2)
+        #thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+        #print 'the thread is .. ', thread
+    #with open('accUnc_mass4l.py', 'w') as f:
+        #acceptance[thread]=interpolate.splev(x, tck)
+            acceptance[thread]=float(interpolate.splev(x, tck1))
+            pdf_uncerUp[thread]=float(interpolate.splev(x, tck2))
+            pdf_uncerDn[thread]=float(interpolate.splev(x, tck3))
+            qcd_uncerUp[thread]=float(interpolate.splev(x, tck4))
+            qcd_uncerDn[thread]=float(interpolate.splev(x, tck5))
+        #qcdunc[thread]=float(interpolate.splev(x, tck3))
+        #print "the acceptance is  ....................", acceptance[thread] #acc_ggH_powheg
+        #print "Bla Bla ....................", acc_ggH_powheg
+	    acc_ggH_powheg[str(thread)]={}
+	    acc_ggH_powheg[str(thread2)]={}
+	    acc_ggH_powheg[str(thread)]=acceptance[thread]
+	    acc_ggH_powheg[str(thread2)]=acc_ggH_powheg[thread0n]*acc_ggH_powheg[str(thread)]/acc_ggH_powheg[str(thread0p)]  #acceptance[thread]
+#            acc_ggH_powheg.update(acceptance)
+        #print "interpol.           acceptance is  ....................", acc_ggH_powheg[str(thread)]#acc_ggH_powheg
+        #print "pdfunc_ggH_powheg                           ",pdfunc_ggH_powheg
+            print "the thread is ...........", thread
+            print "acceptance is.             ", acceptance[thread] #=float(interpolate.splev(x, tck2))
+            print "pdf uncUp is.             ", pdf_uncerUp[thread] #=float(interpolate.splev(x, tck2))
+            print "pdf uncDn is.             ", pdf_uncerDn[thread] #=float(interpolate.splev(x, tck2))
+            print "qcd uncUp is.             ", qcd_uncerUp[thread] #=float(interpolate.splev(x, tck2))
+            print "qcd uncDn is.             ", qcd_uncerDn[thread]
+#pdfunc_ggH_powheg.update(pdfunc)
+        #pdfunc_ggH_powheg.update(pdf_uncerUp)
+        #pdfunc_ggH_powheg[thread]['uncerUp'].update(pdf_uncerUp)
+        #pdfunc_ggH_powheg[thread]['uncerUp'].update(pdf_uncerUp)
+#       pdfunc_ggH_powheg['uncerUp'].update(pdf_uncerUp)  # error#FIXME
+#        print "bla bal is .  ", pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_4mu_'+obsName+'_genbin0']['uncerUp']
+            pdfunc_ggH_powheg[str(thread)]={}
+            pdfunc_ggH_powheg[str(thread2)]={}
+            pdfunc_ggH_powheg[str(thread)]['uncerUp']=pdf_uncerUp[thread]
+	    pdfunc_ggH_powheg[str(thread2)]['uncerUp']=pdfunc_ggH_powheg[thread0n]['uncerUp']*pdfunc_ggH_powheg[str(thread)]['uncerUp']/pdfunc_ggH_powheg[str(thread0p)]['uncerUp']  #acceptance[thread]
+#            pdfunc_ggH_powheg[str(thread2)]['uncerUp']=pdf_uncerUp[thread]
+            pdfunc_ggH_powheg[str(thread)]['uncerDn']=pdf_uncerDn[thread]
+	    pdfunc_ggH_powheg[str(thread2)]['uncerDn']=pdfunc_ggH_powheg[thread0n]['uncerDn']*pdfunc_ggH_powheg[str(thread)]['uncerDn']/pdfunc_ggH_powheg[str(thread0p)]['uncerDn']  #acceptance[thread]
+#            pdfunc_ggH_powheg[str(thread2)]['uncerDn']=pdf_uncerDn[thread]
+
+            qcdunc_ggH_powheg[str(thread)]={}
+            qcdunc_ggH_powheg[str(thread2)]={}
+            qcdunc_ggH_powheg[str(thread)]['uncerUp']=qcd_uncerUp[thread]
+	    qcdunc_ggH_powheg[str(thread2)]['uncerUp']=qcdunc_ggH_powheg[thread0n]['uncerUp']*qcdunc_ggH_powheg[str(thread)]['uncerUp']/qcdunc_ggH_powheg[str(thread0p)]['uncerUp']  #acceptance[thread]
+           # qcdunc_ggH_powheg[str(thread2)]['uncerUp']=qcd_uncerUp[thread]
+            qcdunc_ggH_powheg[str(thread)]['uncerDn']=qcd_uncerDn[thread]
+	    qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcdunc_ggH_powheg[thread0n]['uncerDn']*qcdunc_ggH_powheg[str(thread)]['uncerDn']/qcdunc_ggH_powheg[str(thread0p)]['uncerDn']  #acceptance[thread]
+	    print thread, thread0p, thread2, thread0n
+	    print "qcdunc_ggH_powheg[thread0n]['uncerDn']", qcdunc_ggH_powheg[thread0n]['uncerDn']
+	    print "qcdunc_ggH_powheg[thread]['uncerDn']",qcdunc_ggH_powheg[str(thread)]['uncerDn'] # qcdunc_ggH_powheg[thread0n]['uncerDn']
+	    print "qcdunc_ggH_powheg[thread0p]['uncerDn']",qcdunc_ggH_powheg[str(thread0p)]['uncerDn'] # qcdunc_ggH_powheg[thread0n]['uncerDn']
+            print "qcdunc_ggH_powheg[str(thread2)]['uncerDn']", qcdunc_ggH_powheg[str(thread2)]['uncerDn']
+#            qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcd_uncerDn[thread]
+            #os.system('cp accUnc_'+opt.OBSNAME+'.py accUnc_'+opt.OBSNAME+'_ORIG.py')
+            #os.system('cp accUnc_'+opt.OBSNAME+'_2018.py accUnc_'+opt.OBSNAME+'_2018_ORIG.py')
+            os.system('cp accUnc_'+opt.OBSNAME+'_'+opt.YEAR+'.py accUnc_'+opt.OBSNAME+'_'+opt.YEAR+'_ORIG.py')
+#            os.system('cp accUnc_mass4l_ORIG.py accUnc_mass4l.py')
+#            with open('accUnc_mass4l.py', 'w') as f:
+	    #with open('accUnc_'+obsName+'.py', 'w') as f:
+	    #with open('accUnc_'+obsName+'_2018.py', 'w') as f:
+	    with open('accUnc_'+obsName+'_'+opt.YEAR+'.py', 'w') as f:
+                print "going write interpolated values   "
+                f.write('acc = '+str(acc_ggH_powheg)+' \n')
+                f.write('qcdUncert = '+str(qcdunc_ggH_powheg)+' \n')
+                f.write('pdfUncert = '+str(pdfunc_ggH_powheg)+' \n')
+
+    return interpolate.splev(x, tck1)
+
+global opt, args
+parseOptions()
+observableBins = {0:(opt.OBSBINS.split("|")[1:(len(opt.OBSBINS.split("|"))-1)]),1:['0','inf']}[opt.OBSBINS=='inclusive']
+nbins = len(observableBins)
+obsName = opt.OBSNAME
+
+#value= f(125.38);
+value= f(125.38,nbins,obsName);
+#value= f(125)
+print ("the value is ", value)

--- a/python/interpolate_differential_pred.py
+++ b/python/interpolate_differential_pred.py
@@ -1,7 +1,12 @@
-import sys, os, string, re, pwd, commands, ast, optparse, shlex, time
-import numpy as np
-#import matplotlib.pyplot as plt
+import optparse
+import optparse
+import os
+
 from scipy import interpolate
+
+from Utils import *
+# from python import *
+
 def parseOptions():
 
     global opt, args, runAllSteps
@@ -12,154 +17,133 @@ def parseOptions():
     parser.add_option('',   '--obsName',  dest='OBSNAME',  type='string',default='',   help='Name of the observable, supported: "inclusive", "pT4l", "eta4l", "massZ2", "nJets"')
     parser.add_option('',   '--obsBins',  dest='OBSBINS',  type='string',default='',   help='Bin boundaries for the diff. measurement separated by "|", e.g. as "|0|50|100|", use the defalut if empty string')
     parser.add_option('',   '--year',  dest='YEAR',  type='string',default='2018',   help='Era to analyze, e.g. 2016, 2017, 2018 or Full ')
+    parser.add_option('',   '--debug',  dest='DEBUG',  type='int',default=0,   help='0 if debug false, else debug True')
     global opt, args
     (opt, args) = parser.parse_args()
 
-#
-#def f(x):
-def f(x,n,obsName):
-#def f(mass, channel):
-    #obsName='mass4l'
-   # channel='2e2mu'
+def interpolate_pred(x, nbins, obsName, DEBUG):
+    """Module to get the interpolation from powheg and apply that SF to the NNLOPS sample
+
+    Args:
+        x (float): Mass value for which we need the eff, acc, etc.
+        nbins (int): Number of bins
+        obsName (str): Name of observable
+        DEBUG (bool): True/False depending if you want many printouts or least
+    """
+    if (DEBUG): border_msg("Start of module `interpolate_pred`")
     acceptance={}
-#    pdfunc={}
+    # pdfunc={}
     pdf_uncerUp={}
     pdf_uncerDn={}
     qcd_uncerUp={}
     qcd_uncerDn={}
-    qcdunc={}
-    #_temp = __import__('accUnc_'+obsName, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
-    #_temp = __import__('accUnc_'+obsName'_2018', globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
-    _temp = __import__('accUnc_'+obsName+'_'+opt.YEAR, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
+    # qcdunc={}
+
+    _temp = __import__('accUnc_'+obsName, globals(), locals(), ['acc','pdfUncert','qcdUncert'], -1)
     acc_ggH_powheg = _temp.acc
-    print "acc_ggH_powheg", acc_ggH_powheg
     pdfunc_ggH_powheg = _temp.pdfUncert
     qcdunc_ggH_powheg = _temp.qcdUncert
-# ggH_powheg_JHUgen_126_2e2mu_'+obsName+'_genbin0
-#from scipy import interpolate
-#
-#def f(x):
-    #x_points = [ 0, 1, 2, 3, 4, 5]
+    if (DEBUG): print("[INFO]#L{:3}:  acc_ggH_powheg: {}".format(get_linenumber(), acc_ggH_powheg))
+
     x_points = [124, 125, 126]
-    #x_points = [124, 125, 126,130]
     channels=['4mu','2e2mu','4e']
+    if obsName=='mass4l':
+        channels=['4mu','2e2mu','4e','4l']
 
-    if obsName=='mass4l': channels=['4mu','2e2mu','4e','4l']
-    #y_points = [12,14,22,39,58,77]
-    #y_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_2e2mu_'+obsName+'_genbin0'],acc_ggH_powheg['ggH_powheg_JHUgen_125_2e2mu_'+obsName+'_genbin0'],acc_ggH_powheg['ggH_powheg_JHUgen_126_2e2mu_'+obsName+'_genbin0']]   #  [12,14,22,39,58,77]
     for channel in channels:
-	for obsBin in range(0,n-1):
-        #thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin0'
-            thread0p='ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)
-            thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
-            thread2='ggH_NNLOPS_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
-            thread0n='ggH_NNLOPS_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)
-            print "thread is       ", thread
-            acceptance[thread]=0.0
-            pdf_uncerUp[thread]=0.0
-            pdf_uncerDn[thread]=0.0
-            qcd_uncerUp[thread]=0.0
-            qcd_uncerDn[thread]=0.0
-            #acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]]   #  [12,14,22,39,58,77]
+        for obsBin in range(0, nbins-1):
+            if (DEBUG): border_msg("obsName: {:12} Channel: {:5} obsBin: {:3}".format(obsName, channel, obsBin))
+
+            key_powheg_M125='ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            key_powheg_MX='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            if (DEBUG): print("[INFO]#L{:3}: key_powheg_MX: {}".format(get_linenumber(), key_powheg_MX))
+
+            # FIXME: Later we can generalise this so that we can apply this SF to other samples
+            key_NNLOPS_M125='ggH_NNLOPS_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+            key_NNLOPS_MX='ggH_NNLOPS_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
+
+            # acceptance[key_powheg_MX]=0.0
+            # pdf_uncerUp[key_powheg_MX]=0.0
+            # pdf_uncerDn[key_powheg_MX]=0.0
+            # qcd_uncerUp[key_powheg_MX]=0.0
+            # qcd_uncerDn[key_powheg_MX]=0.0
+
             acc_points = [acc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)],acc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]]   #  [12,14,22,39,58,77]
-	    #pdf_points_uncerUp = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
-	    pdf_points_uncerUp = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
-	    #pdf_points_uncerDn = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']] 
-	    pdf_points_uncerDn = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']] 
-            #qcd_points_uncerUp = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
+            pdf_points_uncerUp = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
+            pdf_points_uncerDn = [pdfunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],pdfunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']]
             qcd_points_uncerUp = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerUp']]   #  [12,14,22,39,58,77]
-            #qcd_points_uncerDn = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_130_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']]   #  [12,14,22,39,58,77]
             qcd_points_uncerDn = [qcdunc_ggH_powheg['ggH_powheg_JHUgen_124_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_125_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn'],qcdunc_ggH_powheg['ggH_powheg_JHUgen_126_'+channel+'_'+obsName+'_genbin'+str(obsBin)]['uncerDn']]   #  [12,14,22,39,58,77]
-            print "obsName is  ..  ", obsName
-            print "channel is ..  ", channel
-            print "acc_points are,,,,,,,,,,,,,,," ,  acc_points
-            print "pdf_points_uncerUp are,,,,,,,,,,,,,,," ,  pdf_points_uncerUp
-            print "pdf_points_uncerDn are,,,,,,,,,,,,,,," ,  pdf_points_uncerDn
-            print "qcd_points_uncerUp are,,,,,,,,,,,,,,," ,  qcd_points_uncerUp
-            print "qcd_points_uncerDn are,,,,,,,,,,,,,,," ,  qcd_points_uncerDn
+
+            if (DEBUG): print("[INFO]#L{:3}: {:21} {}".format(get_linenumber(), "acc_points", acc_points))
+            if (DEBUG): print("[INFO]#L{:3}: {:21} {}".format(get_linenumber(), "pdf_points_uncerUp", pdf_points_uncerUp))
+            if (DEBUG): print("[INFO]#L{:3}: {:21} {}".format(get_linenumber(), "pdf_points_uncerDn", pdf_points_uncerDn))
+            if (DEBUG): print("[INFO]#L{:3}: {:21} {}".format(get_linenumber(), "qcd_points_uncerUp", qcd_points_uncerUp))
+            if (DEBUG): print("[INFO]#L{:3}: {:21} {}".format(get_linenumber(), "qcd_points_uncerDn", qcd_points_uncerDn))
+
+            spl_acc_points                = interpolate.splrep(x_points, acc_points, k=2)
+            spl_pdf_points_uncerUp = interpolate.splrep(x_points, pdf_points_uncerUp, k=2)
+            spl_pdf_points_uncerDn = interpolate.splrep(x_points, pdf_points_uncerDn, k=2)
+            spl_qcd_points_uncerUp = interpolate.splrep(x_points, qcd_points_uncerUp, k=2)
+            spl_qcd_points_uncerDn = interpolate.splrep(x_points, qcd_points_uncerDn, k=2)
+
+            acceptance[key_powheg_MX]    = float(interpolate.splev(x, spl_acc_points))
+            pdf_uncerUp[key_powheg_MX] = float(interpolate.splev(x, spl_pdf_points_uncerUp))
+            pdf_uncerDn[key_powheg_MX] = float(interpolate.splev(x, spl_pdf_points_uncerDn))
+            qcd_uncerUp[key_powheg_MX] = float(interpolate.splev(x, spl_qcd_points_uncerUp))
+            qcd_uncerDn[key_powheg_MX] = float(interpolate.splev(x, spl_qcd_points_uncerDn))
+            #qcdunc[key_powheg_MX]=float(interpolate.splev(x, tck3))
+            if (DEBUG): print("[INFO]#L{:3}: key_powheg_MX                       : {}".format(get_linenumber(), key_powheg_MX ))
+            if (DEBUG): print("[INFO]#L{:3}: acceptance[key_powheg_MX]   : {}".format(get_linenumber(), acceptance[key_powheg_MX] ))
+            if (DEBUG): print("[INFO]#L{:3}: pdf_uncerUp[key_powheg_MX] : {}".format(get_linenumber(), pdf_uncerUp[key_powheg_MX] ))
+            if (DEBUG): print("[INFO]#L{:3}: pdf_uncerDn[key_powheg_MX] : {}".format(get_linenumber(), pdf_uncerDn[key_powheg_MX] ))
+            if (DEBUG): print("[INFO]#L{:3}: qcd_uncerUp[key_powheg_MX] : {}".format(get_linenumber(), qcd_uncerUp[key_powheg_MX] ))
+            if (DEBUG): print("[INFO]#L{:3}: qcd_uncerDn[key_powheg_MX] : {}".format(get_linenumber(), qcd_uncerDn[key_powheg_MX]))
+
+            # Compute the acc, pdf and qcd unc for NNLOPS
+            acc_ggH_powheg[str(key_powheg_MX)] = {}
+            acc_ggH_powheg[str(key_powheg_MX)] = acceptance[key_powheg_MX]
+
+            acc_ggH_powheg[str(key_NNLOPS_MX)] = {}
+            acc_ggH_powheg[str(key_NNLOPS_MX)] = acc_ggH_powheg[key_NNLOPS_M125]*(acc_ggH_powheg[str(key_powheg_MX)]/acc_ggH_powheg[str(key_powheg_M125)] )
+            if (DEBUG): print("[INFO]#L{:3}: acc_ggH_powheg[str(key_NNLOPS_MX)]: {}".format(get_linenumber(), acc_ggH_powheg[str(key_NNLOPS_MX)]))
+
+            pdfunc_ggH_powheg[str(key_powheg_MX)]={}
+            pdfunc_ggH_powheg[str(key_powheg_MX)]['uncerUp'] = pdf_uncerUp[key_powheg_MX]
+            pdfunc_ggH_powheg[str(key_powheg_MX)]['uncerDn']=pdf_uncerDn[key_powheg_MX]
+
+            pdfunc_ggH_powheg[str(key_NNLOPS_MX)]={}
+            pdfunc_ggH_powheg[str(key_NNLOPS_MX)]['uncerUp']=pdfunc_ggH_powheg[key_NNLOPS_M125]['uncerUp']*(pdfunc_ggH_powheg[str(key_powheg_MX)]['uncerUp']/pdfunc_ggH_powheg[str(key_powheg_M125)]['uncerUp'])
+            pdfunc_ggH_powheg[str(key_NNLOPS_MX)]['uncerDn']=pdfunc_ggH_powheg[key_NNLOPS_M125]['uncerDn']*pdfunc_ggH_powheg[str(key_powheg_MX)]['uncerDn']/pdfunc_ggH_powheg[str(key_powheg_M125)]['uncerDn']  #acceptance[key_powheg_MX]
+
+            qcdunc_ggH_powheg[str(key_powheg_MX)]={}
+            qcdunc_ggH_powheg[str(key_powheg_MX)]['uncerUp']=qcd_uncerUp[key_powheg_MX]
+            qcdunc_ggH_powheg[str(key_powheg_MX)]['uncerDn']=qcd_uncerDn[key_powheg_MX]
+
+            qcdunc_ggH_powheg[str(key_NNLOPS_MX)]={}
+            qcdunc_ggH_powheg[str(key_NNLOPS_MX)]['uncerUp']=qcdunc_ggH_powheg[key_NNLOPS_M125]['uncerUp']*qcdunc_ggH_powheg[str(key_powheg_MX)]['uncerUp']/qcdunc_ggH_powheg[str(key_powheg_M125)]['uncerUp']  #acceptance[key_powheg_MX]
+            qcdunc_ggH_powheg[str(key_NNLOPS_MX)]['uncerDn']=qcdunc_ggH_powheg[key_NNLOPS_M125]['uncerDn']*qcdunc_ggH_powheg[str(key_powheg_MX)]['uncerDn']/qcdunc_ggH_powheg[str(key_powheg_M125)]['uncerDn']  #acceptance[key_powheg_MX]
 
 
-    #tck = interpolate.splrep(x_points, y_points)
-            tck1 = interpolate.splrep(x_points, acc_points, k=2)
-            tck2 = interpolate.splrep(x_points, pdf_points_uncerUp, k=2)
-            tck3 = interpolate.splrep(x_points, pdf_points_uncerDn, k=2)
-            tck4 = interpolate.splrep(x_points, qcd_points_uncerUp, k=2)
-            tck5 = interpolate.splrep(x_points, qcd_points_uncerDn, k=2)
-        #thread='ggH_powheg_JHUgen_'+str(x)+'_'+channel+'_'+obsName+'_genbin'+str(obsBin)
-        #print 'the thread is .. ', thread
-    #with open('accUnc_mass4l.py', 'w') as f:
-        #acceptance[thread]=interpolate.splev(x, tck)
-            acceptance[thread]=float(interpolate.splev(x, tck1))
-            pdf_uncerUp[thread]=float(interpolate.splev(x, tck2))
-            pdf_uncerDn[thread]=float(interpolate.splev(x, tck3))
-            qcd_uncerUp[thread]=float(interpolate.splev(x, tck4))
-            qcd_uncerDn[thread]=float(interpolate.splev(x, tck5))
-        #qcdunc[thread]=float(interpolate.splev(x, tck3))
-        #print "the acceptance is  ....................", acceptance[thread] #acc_ggH_powheg
-        #print "Bla Bla ....................", acc_ggH_powheg
-	    acc_ggH_powheg[str(thread)]={}
-	    acc_ggH_powheg[str(thread2)]={}
-	    acc_ggH_powheg[str(thread)]=acceptance[thread]
-	    acc_ggH_powheg[str(thread2)]=acc_ggH_powheg[thread0n]*acc_ggH_powheg[str(thread)]/acc_ggH_powheg[str(thread0p)]  #acceptance[thread]
-#            acc_ggH_powheg.update(acceptance)
-        #print "interpol.           acceptance is  ....................", acc_ggH_powheg[str(thread)]#acc_ggH_powheg
-        #print "pdfunc_ggH_powheg                           ",pdfunc_ggH_powheg
-            print "the thread is ...........", thread
-            print "acceptance is.             ", acceptance[thread] #=float(interpolate.splev(x, tck2))
-            print "pdf uncUp is.             ", pdf_uncerUp[thread] #=float(interpolate.splev(x, tck2))
-            print "pdf uncDn is.             ", pdf_uncerDn[thread] #=float(interpolate.splev(x, tck2))
-            print "qcd uncUp is.             ", qcd_uncerUp[thread] #=float(interpolate.splev(x, tck2))
-            print "qcd uncDn is.             ", qcd_uncerDn[thread]
-#pdfunc_ggH_powheg.update(pdfunc)
-        #pdfunc_ggH_powheg.update(pdf_uncerUp)
-        #pdfunc_ggH_powheg[thread]['uncerUp'].update(pdf_uncerUp)
-        #pdfunc_ggH_powheg[thread]['uncerUp'].update(pdf_uncerUp)
-#       pdfunc_ggH_powheg['uncerUp'].update(pdf_uncerUp)  # error#FIXME
-#        print "bla bal is .  ", pdfunc_ggH_powheg['ggH_powheg_JHUgen_125_4mu_'+obsName+'_genbin0']['uncerUp']
-            pdfunc_ggH_powheg[str(thread)]={}
-            pdfunc_ggH_powheg[str(thread2)]={}
-            pdfunc_ggH_powheg[str(thread)]['uncerUp']=pdf_uncerUp[thread]
-	    pdfunc_ggH_powheg[str(thread2)]['uncerUp']=pdfunc_ggH_powheg[thread0n]['uncerUp']*pdfunc_ggH_powheg[str(thread)]['uncerUp']/pdfunc_ggH_powheg[str(thread0p)]['uncerUp']  #acceptance[thread]
-#            pdfunc_ggH_powheg[str(thread2)]['uncerUp']=pdf_uncerUp[thread]
-            pdfunc_ggH_powheg[str(thread)]['uncerDn']=pdf_uncerDn[thread]
-	    pdfunc_ggH_powheg[str(thread2)]['uncerDn']=pdfunc_ggH_powheg[thread0n]['uncerDn']*pdfunc_ggH_powheg[str(thread)]['uncerDn']/pdfunc_ggH_powheg[str(thread0p)]['uncerDn']  #acceptance[thread]
-#            pdfunc_ggH_powheg[str(thread2)]['uncerDn']=pdf_uncerDn[thread]
+    OutputDictFileName = 'accUnc_'+obsName+'.py'
+    os.system('cp ' + OutputDictFileName + " " + OutputDictFileName.replace('.py','_beforeInterpolation.py'))
 
-            qcdunc_ggH_powheg[str(thread)]={}
-            qcdunc_ggH_powheg[str(thread2)]={}
-            qcdunc_ggH_powheg[str(thread)]['uncerUp']=qcd_uncerUp[thread]
-	    qcdunc_ggH_powheg[str(thread2)]['uncerUp']=qcdunc_ggH_powheg[thread0n]['uncerUp']*qcdunc_ggH_powheg[str(thread)]['uncerUp']/qcdunc_ggH_powheg[str(thread0p)]['uncerUp']  #acceptance[thread]
-           # qcdunc_ggH_powheg[str(thread2)]['uncerUp']=qcd_uncerUp[thread]
-            qcdunc_ggH_powheg[str(thread)]['uncerDn']=qcd_uncerDn[thread]
-	    qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcdunc_ggH_powheg[thread0n]['uncerDn']*qcdunc_ggH_powheg[str(thread)]['uncerDn']/qcdunc_ggH_powheg[str(thread0p)]['uncerDn']  #acceptance[thread]
-	    print thread, thread0p, thread2, thread0n
-	    print "qcdunc_ggH_powheg[thread0n]['uncerDn']", qcdunc_ggH_powheg[thread0n]['uncerDn']
-	    print "qcdunc_ggH_powheg[thread]['uncerDn']",qcdunc_ggH_powheg[str(thread)]['uncerDn'] # qcdunc_ggH_powheg[thread0n]['uncerDn']
-	    print "qcdunc_ggH_powheg[thread0p]['uncerDn']",qcdunc_ggH_powheg[str(thread0p)]['uncerDn'] # qcdunc_ggH_powheg[thread0n]['uncerDn']
-            print "qcdunc_ggH_powheg[str(thread2)]['uncerDn']", qcdunc_ggH_powheg[str(thread2)]['uncerDn']
-#            qcdunc_ggH_powheg[str(thread2)]['uncerDn']=qcd_uncerDn[thread]
-            #os.system('cp accUnc_'+opt.OBSNAME+'.py accUnc_'+opt.OBSNAME+'_ORIG.py')
-            #os.system('cp accUnc_'+opt.OBSNAME+'_2018.py accUnc_'+opt.OBSNAME+'_2018_ORIG.py')
-            os.system('cp accUnc_'+opt.OBSNAME+'_'+opt.YEAR+'.py accUnc_'+opt.OBSNAME+'_'+opt.YEAR+'_ORIG.py')
-#            os.system('cp accUnc_mass4l_ORIG.py accUnc_mass4l.py')
-#            with open('accUnc_mass4l.py', 'w') as f:
-	    #with open('accUnc_'+obsName+'.py', 'w') as f:
-	    #with open('accUnc_'+obsName+'_2018.py', 'w') as f:
-	    with open('accUnc_'+obsName+'_'+opt.YEAR+'.py', 'w') as f:
-                print "going write interpolated values   "
-                f.write('acc = '+str(acc_ggH_powheg)+' \n')
-                f.write('qcdUncert = '+str(qcdunc_ggH_powheg)+' \n')
-                f.write('pdfUncert = '+str(pdfunc_ggH_powheg)+' \n')
+    with open(OutputDictFileName, 'w') as f:
+        print("going write interpolated values in file:   " + OutputDictFileName)
+        f.write('acc = '+str(acc_ggH_powheg)+' \n')
+        f.write('qcdUncert = '+str(qcdunc_ggH_powheg)+' \n')
+        f.write('pdfUncert = '+str(pdfunc_ggH_powheg)+' \n')
 
-    return interpolate.splev(x, tck1)
+if __name__ == "__main__":
 
-global opt, args
-parseOptions()
-observableBins = {0:(opt.OBSBINS.split("|")[1:(len(opt.OBSBINS.split("|"))-1)]),1:['0','inf']}[opt.OBSBINS=='inclusive']
-nbins = len(observableBins)
-obsName = opt.OBSNAME
+    global opt, args
+    parseOptions()
 
-#value= f(125.38);
-value= f(125.38,nbins,obsName);
-#value= f(125)
-print ("the value is ", value)
+    observableBins = {0:(opt.OBSBINS.split("|")[1:(len(opt.OBSBINS.split("|"))-1)]),1:['0','inf']}[opt.OBSBINS=='inclusive']
+    nbins = len(observableBins)
+
+    print("\n==> Obs Name: {:15}  nBins: {:2}  bins: {}".format(opt.OBSNAME, nbins, observableBins))
+
+    interpolate_pred(125.38, nbins, opt.OBSNAME,  opt.DEBUG);
+
+    print("Interpolation completed... :) ")
+    print("----------\n")

--- a/python/sample_shortnames.py
+++ b/python/sample_shortnames.py
@@ -1,5 +1,7 @@
 sample_shortnames = {
+    'GluGluHToZZTo4L_M124_2018_slimmed' :'ggH_powheg_JHUgen_124',
     'GluGluHToZZTo4L_M125_2018_slimmed' :'ggH_powheg_JHUgen_125',
+    'GluGluHToZZTo4L_M126_2018_slimmed' :'ggH_powheg_JHUgen_126',
     'testGGH_nnlops_GENonly_slimmed'    :'ggH_NNLOPS_JHUgen_125',
     'VBF_HToZZTo4L_M125_2018_slimmed'   :'VBF_powheg_JHUgen_125',
     'WH_HToZZTo4L_M125_2018_slimmed'    :'WH_powheg_JHUgen_125',


### PR DESCRIPTION
- Added two interpolation modules from https://github.com/vukasinmilosevic/Fiducial_XS/pull/2 and updated.
   1.  First is to get the powheg hgg M124, M125, M126 sample, then interpolate to get the eff, acc, etc for M125.38.
   2. Second is to grab the ratio of M125 and M125.38 from powheg then apply this SF to NNLOPS M125 sample, to get the values for M125.38.
- Updated README accordingly.

To-Do:

- The 2nd module i.e. [interpolate_differential_pred.py](https://github.com/ram1123/Fiducial_XS/blob/72baabdc757c99be9b748700a76ab1561249cdc6/python/interpolate_differential_pred.py) should be generalised. So, that we can do the same for Madgraph or other generators.