### PR TITLE
2D obs update running version of template maker and create WS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ templatesXS/
 xs_*/
 plots/
 table/
+Inputs/.__afsB8D6

--- a/Inputs/Input_Info.py
+++ b/Inputs/Input_Info.py
@@ -18,6 +18,13 @@ combineOutputs = "xs_125.0"
 
 SigEfficiencyPlots = "plots/SigEfficiency/2018/{obsName}"
 
+DifferentialBins = "plots/DifferentialBins/2018/{obsName}"
+
+AsimovPlots = "plots/plotAsimov/2018/{obsName}"
+
+LHScanPlots =  "plots/LHScanPlots/2018/{obsName}"
+
+ResultsPlot = "plots/results/2018/"
 ################################
 # Paths of ntuples
 ################################

--- a/Inputs/observables_list.yml
+++ b/Inputs/observables_list.yml
@@ -81,23 +81,10 @@ Observables:
      gen: "GENnjets_pt30_eta2p5"
 
 
-  # Copied the 2D values from here: https://github.com/tjavaid/DDXS/blob/d3f9cadc5967d713e077fbbd8a89cb14f7e39fb0/doAllEffs_channels_DXS.sh
   2D_Observables:
 
-    1:
-      massZ1:
-        bins: "|50.0|74.0|88.0|94.0|106.0|"
-      massZ2:
-        bins: "|12|24|"
-
-    2:
-      massZ1:
-        bins: "|50.0|74.0|88.0|94.0|106.0|"
-      massZ2:
-        bins: "|24|32|"
-
-    3:
-      massZ1:
-        bins: "|50.0|74.0|88.0|94.0|106.0|"
-      massZ2:
-        bins: "|32|65|"
+      "massZ1 vs massZ2":
+        bins: "|50|80| vs |10|30| / |50|80| vs |30|60| / |80|110| vs |10|25| / |80|110| vs |25|30|"
+        label: ""
+        unit: ""
+        gen: ""

--- a/Inputs/observables_list.yml
+++ b/Inputs/observables_list.yml
@@ -13,78 +13,102 @@ Observables:
      label: "M_{4l}"
      unit: "GeV"
      gen: "GENmass4l"
+     ifAbs: False
 
     pT4l:
      bins: "|0|10|20|30|45|60|80|120|200|13000|"
      label: "p_{T}(H)"
      unit: "GeV"
      gen: "GENpT4l"
+     ifAbs: False
 
     rapidity4l:
      bins: "|0.0|0.15|0.3|0.45|0.6|0.75|0.9|1.2|1.6|2.5|"
      label: "|y(H)|"
      unit: ""
      gen: "GENrapidity4l"
+     ifAbs: False
 
     cosTheta1:
      bins: "|-1.0|-0.75|-0.5|-0.25|0.0|0.25|0.5|0.75|1.0|"
      label: "cos(#theta_{1})"
      unit: ""
      gen: "GENcosTheta1"
+     ifAbs: False
 
     cosTheta2:
      bins: "|-1.0|-0.75|-0.5|-0.25|0.0|0.25|0.5|0.75|1.0|"
      label: "cos(#theta_{2})"
      unit: ""
      gen: "GENcosTheta2"
+     ifAbs: False
 
     Phi:
      bins: "|-3.14159|-2.35619|-1.570795|-0.7853975|0.0|0.7853975|1.570795|2.35619|3.14159|"
      label: "#Phi"
      unit: ""
      gen: "GENPhi"
+     ifAbs: False
 
     Phi1:
      bins: "|-3.14159|-2.35619|-1.570795|-0.7853975|0.0|0.7853975|1.570795|2.35619|3.14159|"
      label: "#Phi_{1}"
      unit: ""
      gen: "GENPhi1"
+     ifAbs: False
 
     cosThetaStar:
       bins: "|-1.0|-0.75|-0.5|-0.25|0.0|0.25|0.5|0.75|1.0|"
       label: "cos(#theta*)"
       unit: ""
       gen: "GENcosThetaStar"
+     ifAbs: False
 
     massZ1:
      bins: "|40.0|65.0|73.0|80.0|85.0|90.0|120.0|"
      label: "m(Z_{1})"
      unit: "GeV"
      gen: "GENmassZ1"
+     ifAbs: False
 
     massZ2:
      bins: "|12.0|22.0|25.0|28.0|30.0|32.0|35.0|40.0|50.0|65.0|"
      label: "m(Z_{2})"
      unit: "GeV"
      gen: "GENmassZ2"
+     ifAbs: False
 
     pt_leadingjet_pt30_eta2p5:
      bins: "|-2.0|30.0|55.0|95.0|200.0|13000.0|"
      label: "p_{T}(jet) |#eta|<2.5"
      unit: "GeV"
      gen: "GENpt_leadingjet_pt30_eta2p5"
+     ifAbs: False
 
     njets_pt30_eta2p5:
      bins: "|0.0|1.0|2.0|3.0|4.0|10.0|"
      label: "N(jets) |#eta|<2.5"
      unit: ""
      gen: "GENnjets_pt30_eta2p5"
+     ifAbs: False
 
 
   2D_Observables:
 
       "massZ1 vs massZ2":
         bins: "|50|80| vs |10|30| / |50|80| vs |30|60| / |80|110| vs |10|25| / |80|110| vs |25|30|"
+        label: ""
+        unit: ""
+        gen: ""
+
+      "njets_pt30_eta2p5 vs pT4l":
+        bins: '|0|1|2|3|20| vs |0|15|30|120|350| / |0|15|30|120|350| / |0|120|350| / |0|120|350|'
+        label: ""
+        unit: ""
+        gen: ""
+
+      "rapidity4l vs pT4l":
+        bins: '|0.0|0.5| vs |0|40| / |0.0|0.5| vs |40|80| / |0.0|0.5| vs |80|150| / |0.0|0.5| vs |150|1300| / |0.5|1.0| vs |0|45| / |0.5|1.0| vs |45|120| / |0.5|1.0| vs |120|1300| / |1.0|2.5| vs |0|45| / |1.0|2.5| vs |45|120| / |1.0|2.5| vs |120|1300|'
         label: ""
         unit: ""
         gen: ""

--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ Things to fix
 Specific
 ^^^^^^^^^^^^^^^^^^^
 1. Hardcoded paths in `LoadData.py <https://github.com/vukasinmilosevic/Fiducial_XS/edit/CMSSW_10_X_VM_docs/python/LoadData.py#8/>`_
-
+1. Currently, the framework will work if all samples exists in the same directory, including the Z+X files.
 
 General
 ^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,9 @@ Hardcoded Informations
     1D_Observables:
       mass4l:
         - bins: "|105.0|140.0|"
+    2D_Observables:
+      mass4l:
+        - bins: "|105.0|140.0|"
   ```
 
-  In this YAML file the two names `Observables` and `1D_Observables` should remain same, else the code will give error.
+  In this YAML file the two names `Observables`, `1D_Observables` and `2D_Observables` should remain same, else the code will give error.

--- a/RunEverything.py
+++ b/RunEverything.py
@@ -12,7 +12,7 @@ except ImportError as e:
     raise ImportError("Check if you run `source setup.sh`. If not please run it.\n")
 
 try:
-    from Utils import logging, ColorLogFormatter, border_msg
+    from Utils import logging, logger, ColorLogFormatter, border_msg
 except Exception as e:
     print (e)
     raise ImportError("Check if you run `source setup.sh`. If not please run it.\n")
@@ -44,11 +44,7 @@ parser.add_argument(
      )
 args = parser.parse_args()
 
-# Setup logger
-logger = logging.getLogger(__name__)
-stream_handler = logging.StreamHandler()
-stream_handler.setFormatter(ColorLogFormatter())
-logger.addHandler(stream_handler)
+# Setup logger level
 logger.setLevel(args.log_level)
 
 # create a directory named "log" to save nohup outputs.

--- a/RunEverything.py
+++ b/RunEverything.py
@@ -36,32 +36,35 @@ parser.add_argument( '-model', dest='modelNames', default="SM_125,SMup_125,SMdn_
 parser.add_argument( '-p', dest='NtupleDir', default="/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/", help='Path of ntuples')
 parser.add_argument( '-m', dest='HiggsMass', default=125.0, type=float, help='Higgs mass')
 parser.add_argument( '-r', dest='RunCommand', default=0, type=int, choices=[0, 1], help="if 1 then it will run the commands else it will just print the commands")
+parser.add_argument( '-obs', dest='OneDOr2DObs', default=1, type=int, choices=[1, 2], help="1 for 1D obs, 2 for 2D observable")
 
 args = parser.parse_args()
 
+# create a directory named "log" to save nohup outputs.
 if not os.path.isdir('log'): os.mkdir('log')
 
-
 InputYAMLFile = args.inYAMLFile
+ObsToStudy = "1D_Observables" if args.OneDOr2DObs == 1 else "2D_Observables"
 
 with open(InputYAMLFile, 'r') as ymlfile:
     cfg = yaml.load(ymlfile)
 
-    if ( ("Observables" not in cfg) or ("1D_Observables" not in cfg['Observables']) ) :
+    if ( ("Observables" not in cfg) or (ObsToStudy not in cfg['Observables']) ) :
         print('''No section named 'observable' or sub-section name '1D-Observable' found in file {}.
                  Please check your YAML file format!!!'''.format(InputYAMLFile))
 
-    if "1D_Observables" in cfg['Observables']:
-        for obsName, obsBin in cfg['Observables']['1D_Observables'].items():
+
+    if ObsToStudy in cfg['Observables']:
+        for obsName, obsBin in cfg['Observables'][ObsToStudy].items():
             print("="*51)
             print("Observable: {:11} Bins: {}".format(obsName, obsBin['bins']))
             if (args.step == 1):
                 border_msg("Running the efficiencies step")
                 for channel in args.channels:
                     print("==> channel: {}".format(channel))
-                    command = 'nohup python -u efficiencyFactors.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -c "{channel}" >& log/effs_{obsName}_{channel}.log &'.format(
+                    command = 'nohup python -u efficiencyFactors.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -c "{channel}" >& log/effs_{obsName_log}_{channel}.log &'.format(
                     # command = 'python -u efficiencyFactors.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -c "{channel}"'.format(
-                        obsName = obsName, obsBins = obsBin['bins'], channel = channel
+                        obsName = obsName, obsBins = obsBin['bins'], channel = channel, obsName_log = obsName.replace(" ","_")
                     )
                     print("Command: {}".format(command))
                     if (args.RunCommand): os.system(command)

--- a/RunEverything.py
+++ b/RunEverything.py
@@ -83,14 +83,15 @@ with open(InputYAMLFile, 'r') as ymlfile:
                 logger.info("="*51)
 
                 # FIXME: Currently the plotter is only working for 1D vars.
-                if ((not obsName.startswith("mass4l") ) or (ObsToStudy != "2D_Observables")):
+                if ((not obsName.startswith("mass4l") ) and (ObsToStudy != "2D_Observables")):
                     border_msg("Running plotter to plot 2D signal efficiencies")
                     command = 'python python/plot2dsigeffs.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" --inYAMLFile="{inYAMLFile}"'.format(
                         obsName = obsName, obsBins = obsBin['bins'], inYAMLFile = args.inYAMLFile
                     )
                     logger.info("Command: {}".format(command))
                     if (args.RunCommand): os.system(command)
-
+                else:
+                    logger.info("Not running `plot2dsigeffs.py` as either the choosen option is `mass4l` or `2D observables`.")
             if (args.step == 3):
                 border_msg("Running getUnc: "+ obsName)
                 # command = 'python -u getUnc_Unc.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" >& log/unc_{obsName}.log &'.format(

--- a/RunEverything.py
+++ b/RunEverything.py
@@ -12,7 +12,7 @@ except ImportError as e:
     raise ImportError("Check if you run `source setup.sh`. If not please run it.\n")
 
 try:
-    from Utils import logging, logger, ColorLogFormatter, border_msg
+    from Utils import logging, logger, border_msg
 except Exception as e:
     print (e)
     raise ImportError("Check if you run `source setup.sh`. If not please run it.\n")

--- a/efficiencyFactors.py
+++ b/efficiencyFactors.py
@@ -6,7 +6,6 @@ import sys
 from decimal import *
 from math import *
 from random import sample
-import time
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
@@ -54,7 +53,6 @@ def parseOptions():
     global opt, args
     (opt, args) = parser.parse_args()
 
-start = time.time()
 # parse the arguments and options
 global opt, args, runAllSteps
 parseOptions()
@@ -119,7 +117,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
     logging.info(sample)
     if ("NNLOPS" in sample or "nnlops" in sample):
         print ("Will skip: "+ sample)
-
+    
     recoweight = "genWeight*pileupWeight*dataMCWeight"
 
 
@@ -263,15 +261,15 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             cutobs_reco = "("+obs_reco+">="+str(obs_reco_low)+")"
 
         # Double differential measurement addition for the reco observable cut
-
-
+       
+        
         tmp = ''
         if not (obs_reco2 == ''):
             tmp = " && ("+obs_reco2+">="+str(obs_reco2_low)+" && "+obs_reco2+"<"+str(obs_reco2_high)+")"
 
             if obs_reco2_high == "inf":
                 tmp = " && ("+obs_reco2+">="+str(obs_reco2_low)+")"
-
+                
             cutobs_reco += tmp
 
         print(bcolors.HEADER + "cutobs_reco:" + bcolors.ENDC)
@@ -280,7 +278,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
         # Generator observable cut - important to keep it in the desired bin range
 
-
+     
 
         cutobs_gen = "("+obs_gen+">="+str(obs_gen_low)+" && "+obs_gen+"<"+str(obs_gen_high)+")"
 
@@ -295,7 +293,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
             if obs_gen2_high == "inf":
                 tmp = " && ("+obs_gen2+">="+str(obs_gen2_low)+")"
-
+                
             cutobs_gen += tmp
 
         print(bcolors.HEADER + "cutobs_gen:" + bcolors.ENDC)
@@ -311,7 +309,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             if obs_reco_high == "inf":
                 cutobs_reco_jesup = "("+obs_reco+"_jesup"+">="+str(obs_reco_low)+")"
                 cutobs_reco_jesdn = "("+obs_reco+"_jesdn"+">="+str(obs_reco_low)+")"
-
+           
             # Double differential measurement addition: Reco observable cut - if using the _jesup/down variations
             tmp_up = ''
             tmp_dn = ''
@@ -333,7 +331,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             print(cutobs_reco_jesdn)
 
         # Generator level selection on the out of the fiducial range - i.e. outside of the deisred bin, but still within the high/low range for the observed variable.
-
+        
         cutobs_gen_otherfid = "(("+obs_gen+"<"+str(obs_gen_low)+" && "+obs_gen+">="+str(obs_gen_lowest)+") || ("+obs_gen+">="+str(obs_gen_high)+" && "+obs_gen+"<="+str(obs_gen_highest)+"))"
 
         if obs_gen_highest == "inf": # can use a check like this because gen and reco bin boundaries are the same - so either reco or gen is ok, but gen is better following the cut logic
@@ -342,7 +340,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
             else:
                 cutobs_gen_otherfid = "(("+obs_gen+"<"+str(obs_gen_low)+" && "+obs_gen+">="+str(obs_gen_lowest)+") || ("+obs_gen+">="+str(obs_gen_high)+"))"
-
+            
 
         # Double differential measurement addition: Generator level selection on the out of the fiducial range - i.e. outside of the deisred bin, but still within the high/low range for the observed variable.
         ### FIXME: For now implementing how it was agreed with LLR, but this should be understood
@@ -354,7 +352,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             if obs_gen2_highest == "inf":
                 if obs_gen2_high == "inf":
                     tmp = " || (("+obs_gen2+"<"+str(obs_gen2_low)+" && "+obs_gen2+">="+str(obs_gen2_lowest)+"))"
-
+                
                 else:
                     tmp = " || (("+obs_gen2+"<"+str(obs_gen2_low)+" && "+obs_gen2+">="+str(obs_gen2_lowest)+") || ("+obs_gen2+">="+str(obs_gen2_high)+"))"
 
@@ -386,7 +384,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             cutchan_gen_out  = "((GENZ_DaughtersId[0]==11 && GENZ_DaughtersId[1]==13) || (GENZ_DaughtersId[0]==13 && GENZ_DaughtersId[1]==11))"
             cutm4l_gen       = "(GENmass4l>"+str(m4l_low)+" && GENmass4l<"+str(m4l_high)+")"
             cutm4l_reco      = "(mass2e2mu>"+str(m4l_low)+" && mass2e2mu<"+str(m4l_high)+")"
-
+            
         #Generator level requirement for the Higgs boson being the Allfather :D
         cuth4l_gen  = "(GENlep_MomMomId[GENlep_Hindex[0]]==25 && GENlep_MomMomId[GENlep_Hindex[1]]==25 && GENlep_MomMomId[GENlep_Hindex[2]]==25 && GENlep_MomMomId[GENlep_Hindex[3]]==25)"
         #Reco level requirement for the Higgs boson being the Allfather (yes, I'm going with Odin reference) :D
@@ -408,9 +406,9 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
         # Setting up the correct generator weight variable
         # FIXME: Why 10000 factor?
-        if (recoweight=="totalWeight"):
+        if (recoweight=="totalWeight"): 
             genweight = "10000.0*genWeight/"+str(sumw[Sample])
-        else:
+        else: 
             genweight = "genWeight"
 
         # RECO level histograms initialisation
@@ -926,7 +924,7 @@ Nbins = len(obs_bins)
 
 if obs_reco2 == '':
     Nbins = Nbins - 1 #  For the double diff measurement the len(obs_bins) is the actual number of bins, while for the 1 observable we parse bin edges so it needs to be len -1
-
+    
 
 for chan in chans:
     for recobin in range(Nbins):
@@ -979,5 +977,3 @@ with open(more_output_file_name, 'w') as f:
     #f.write('effanyreco = '+str(effanyreco)+' \n')
     #f.write('deffanyreco = '+str(deffanyreco)+' \n')
 print "All samples in all process bins compiled!"
-end = time.time()
-print("The time of execution of this program is :", end-start)

--- a/efficiencyFactors.py
+++ b/efficiencyFactors.py
@@ -6,6 +6,7 @@ import sys
 from decimal import *
 from math import *
 from random import sample
+import time
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
@@ -53,6 +54,7 @@ def parseOptions():
     global opt, args
     (opt, args) = parser.parse_args()
 
+start = time.time()
 # parse the arguments and options
 global opt, args, runAllSteps
 parseOptions()
@@ -117,7 +119,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
     logging.info(sample)
     if ("NNLOPS" in sample or "nnlops" in sample):
         print ("Will skip: "+ sample)
-    
+
     recoweight = "genWeight*pileupWeight*dataMCWeight"
 
 
@@ -261,15 +263,15 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             cutobs_reco = "("+obs_reco+">="+str(obs_reco_low)+")"
 
         # Double differential measurement addition for the reco observable cut
-       
-        
+
+
         tmp = ''
         if not (obs_reco2 == ''):
             tmp = " && ("+obs_reco2+">="+str(obs_reco2_low)+" && "+obs_reco2+"<"+str(obs_reco2_high)+")"
 
             if obs_reco2_high == "inf":
                 tmp = " && ("+obs_reco2+">="+str(obs_reco2_low)+")"
-                
+
             cutobs_reco += tmp
 
         print(bcolors.HEADER + "cutobs_reco:" + bcolors.ENDC)
@@ -278,7 +280,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
         # Generator observable cut - important to keep it in the desired bin range
 
-     
+
 
         cutobs_gen = "("+obs_gen+">="+str(obs_gen_low)+" && "+obs_gen+"<"+str(obs_gen_high)+")"
 
@@ -293,7 +295,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
             if obs_gen2_high == "inf":
                 tmp = " && ("+obs_gen2+">="+str(obs_gen2_low)+")"
-                
+
             cutobs_gen += tmp
 
         print(bcolors.HEADER + "cutobs_gen:" + bcolors.ENDC)
@@ -309,7 +311,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             if obs_reco_high == "inf":
                 cutobs_reco_jesup = "("+obs_reco+"_jesup"+">="+str(obs_reco_low)+")"
                 cutobs_reco_jesdn = "("+obs_reco+"_jesdn"+">="+str(obs_reco_low)+")"
-           
+
             # Double differential measurement addition: Reco observable cut - if using the _jesup/down variations
             tmp_up = ''
             tmp_dn = ''
@@ -331,7 +333,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             print(cutobs_reco_jesdn)
 
         # Generator level selection on the out of the fiducial range - i.e. outside of the deisred bin, but still within the high/low range for the observed variable.
-        
+
         cutobs_gen_otherfid = "(("+obs_gen+"<"+str(obs_gen_low)+" && "+obs_gen+">="+str(obs_gen_lowest)+") || ("+obs_gen+">="+str(obs_gen_high)+" && "+obs_gen+"<="+str(obs_gen_highest)+"))"
 
         if obs_gen_highest == "inf": # can use a check like this because gen and reco bin boundaries are the same - so either reco or gen is ok, but gen is better following the cut logic
@@ -340,7 +342,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
             else:
                 cutobs_gen_otherfid = "(("+obs_gen+"<"+str(obs_gen_low)+" && "+obs_gen+">="+str(obs_gen_lowest)+") || ("+obs_gen+">="+str(obs_gen_high)+"))"
-            
+
 
         # Double differential measurement addition: Generator level selection on the out of the fiducial range - i.e. outside of the deisred bin, but still within the high/low range for the observed variable.
         ### FIXME: For now implementing how it was agreed with LLR, but this should be understood
@@ -352,7 +354,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             if obs_gen2_highest == "inf":
                 if obs_gen2_high == "inf":
                     tmp = " || (("+obs_gen2+"<"+str(obs_gen2_low)+" && "+obs_gen2+">="+str(obs_gen2_lowest)+"))"
-                
+
                 else:
                     tmp = " || (("+obs_gen2+"<"+str(obs_gen2_low)+" && "+obs_gen2+">="+str(obs_gen2_lowest)+") || ("+obs_gen2+">="+str(obs_gen2_high)+"))"
 
@@ -384,7 +386,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             cutchan_gen_out  = "((GENZ_DaughtersId[0]==11 && GENZ_DaughtersId[1]==13) || (GENZ_DaughtersId[0]==13 && GENZ_DaughtersId[1]==11))"
             cutm4l_gen       = "(GENmass4l>"+str(m4l_low)+" && GENmass4l<"+str(m4l_high)+")"
             cutm4l_reco      = "(mass2e2mu>"+str(m4l_low)+" && mass2e2mu<"+str(m4l_high)+")"
-            
+
         #Generator level requirement for the Higgs boson being the Allfather :D
         cuth4l_gen  = "(GENlep_MomMomId[GENlep_Hindex[0]]==25 && GENlep_MomMomId[GENlep_Hindex[1]]==25 && GENlep_MomMomId[GENlep_Hindex[2]]==25 && GENlep_MomMomId[GENlep_Hindex[3]]==25)"
         #Reco level requirement for the Higgs boson being the Allfather (yes, I'm going with Odin reference) :D
@@ -406,9 +408,9 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
 
         # Setting up the correct generator weight variable
         # FIXME: Why 10000 factor?
-        if (recoweight=="totalWeight"): 
+        if (recoweight=="totalWeight"):
             genweight = "10000.0*genWeight/"+str(sumw[Sample])
-        else: 
+        else:
             genweight = "genWeight"
 
         # RECO level histograms initialisation
@@ -924,7 +926,7 @@ Nbins = len(obs_bins)
 
 if obs_reco2 == '':
     Nbins = Nbins - 1 #  For the double diff measurement the len(obs_bins) is the actual number of bins, while for the 1 observable we parse bin edges so it needs to be len -1
-    
+
 
 for chan in chans:
     for recobin in range(Nbins):
@@ -977,3 +979,5 @@ with open(more_output_file_name, 'w') as f:
     #f.write('effanyreco = '+str(effanyreco)+' \n')
     #f.write('deffanyreco = '+str(deffanyreco)+' \n')
 print "All samples in all process bins compiled!"
+end = time.time()
+print("The time of execution of this program is :", end-start)

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -77,7 +77,8 @@ class ColorLogFormatter(logging.Formatter):
      """
 
      # FORMAT = "%(prefix)s%(msg)s%(suffix)s"
-     FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
+    #  FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
+     FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s - %(message)s %(suffix)s\n"
     #  FORMAT = "\n%(asctime)s - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
 
      LOG_LEVEL_COLOR = {
@@ -98,3 +99,15 @@ class ColorLogFormatter(logging.Formatter):
 
          formatter = logging.Formatter(self.FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p' )
          return formatter.format(record)
+
+logger = logging.getLogger(__name__)
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(ColorLogFormatter())
+logger.addHandler(stream_handler)
+logger.setLevel( logging.DEBUG)
+
+# log_level_map = {
+#     "0": logging.WARNING,
+#     "1": logging.INFO,
+#     "2": logging.DEBUG
+# }

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -1,3 +1,9 @@
+import logging
+import os
+from inspect import currentframe
+from subprocess import *
+
+
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -8,7 +14,6 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
-
 
 def border_msg(msg):
     """Print message inside the border
@@ -30,6 +35,10 @@ def fixed_border_msg(msg):
     border = "="*51
     result = border + "\n" + msg + "\n" + border
     print(result)
+
+def get_linenumber():
+    cf = currentframe()
+    return cf.f_back.f_lineno
 
 def processCmd(cmd, lineNumber, quiet = 0):
     """This function is defined for processing of os command
@@ -61,3 +70,31 @@ def processCmd(cmd, lineNumber, quiet = 0):
         print ('Output:\n   [{}] \n'.format(output))
 
     return output
+
+class ColorLogFormatter(logging.Formatter):
+     """A class for formatting colored logs.
+     Reference: https://stackoverflow.com/a/70796089/2302094
+     """
+
+     # FORMAT = "%(prefix)s%(msg)s%(suffix)s"
+     FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
+    #  FORMAT = "\n%(asctime)s - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
+
+     LOG_LEVEL_COLOR = {
+         "DEBUG": {'prefix': bcolors.OKBLUE, 'suffix': bcolors.ENDC},
+         "INFO": {'prefix': bcolors.OKGREEN, 'suffix': bcolors.ENDC},
+         "WARNING": {'prefix': bcolors.WARNING, 'suffix': bcolors.ENDC},
+         "ERROR": {'prefix': bcolors.FAIL+bcolors.BOLD, 'suffix': bcolors.ENDC+bcolors.ENDC},
+         "CRITICAL": {'prefix': bcolors.FAIL, 'suffix': bcolors.ENDC},
+     }
+
+     def format(self, record):
+         """Format log records with a default prefix and suffix to terminal color codes that corresponds to the log level name."""
+         if not hasattr(record, 'prefix'):
+             record.prefix = self.LOG_LEVEL_COLOR.get(record.levelname.upper()).get('prefix')
+
+         if not hasattr(record, 'suffix'):
+             record.suffix = self.LOG_LEVEL_COLOR.get(record.levelname.upper()).get('suffix')
+
+         formatter = logging.Formatter(self.FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p' )
+         return formatter.format(record)

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -15,63 +15,6 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-def border_msg(msg):
-    """Print message inside the border
-
-    >>> border_msg('hello')
-        +-----+
-        |hello|
-        +-----+
-
-    Args:
-        msg (str): message to print inside border
-    """
-    row = len(msg)+4
-    h = ''.join(['+'] + ['-' *row] + ['+'])
-    result= h + '\n'"|  "+msg+"  |"'\n' + h
-    print(bcolors.OKGREEN + result +  bcolors.ENDC)
-
-def fixed_border_msg(msg):
-    border = "="*51
-    result = border + "\n" + msg + "\n" + border
-    print(result)
-
-def get_linenumber():
-    cf = currentframe()
-    return cf.f_back.f_lineno
-
-def processCmd(cmd, lineNumber = 0, quiet = 0):
-    """This function is defined for processing of os command
-
-    Args:
-        cmd (str): The command to be run on the terminal
-        lineNumber (int): The line number from where this function was invoked
-        quiet (int, optional): Want to run the command in quite mode (Don't print anything) or print everything. Defaults to 0.
-
-    Raises:
-        RuntimeError: If the command failed then exit the program with exit code
-
-    Returns:
-        str: The full output of the command
-    """
-    output = '\n'
-    print("="*51)
-    print("[INFO]: Current working directory: {0}".format(os.getcwd()))
-    print("[INFO]: {}#{} command:\n\t{}".format(os.path.basename(__file__), lineNumber, cmd)) # FIXME: now its always take filename as `Utils.py`. It should take the file name from where its called.
-    p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, bufsize=-1)
-    for line in iter(p.stdout.readline, ''):
-        output=output+str(line)
-    p.stdout.close()
-
-    if p.wait() != 0:
-        raise RuntimeError("%r failed, exit status: %d" % (cmd, p.returncode))
-
-    if (not quiet):
-        print ('Output:\n   [{}] \n'.format(output))
-    print("="*51)
-
-    return output
-
 class ColorLogFormatter(logging.Formatter):
      """A class for formatting colored logs.
      Reference: https://stackoverflow.com/a/70796089/2302094
@@ -114,3 +57,62 @@ logger.setLevel( logging.DEBUG)
 #     "1": logging.INFO,
 #     "2": logging.DEBUG
 # }
+
+def border_msg(msg):
+    """Print message inside the border
+
+    >>> border_msg('hello')
+        +-----+
+        |hello|
+        +-----+
+
+    Args:
+        msg (str): message to print inside border
+    """
+    row = len(msg)+4
+    h = ''.join(['+'] + ['-' *row] + ['+'])
+    result= h + '\n'"|  "+msg+"  |"'\n' + h
+    print(bcolors.OKGREEN + result +  bcolors.ENDC)
+
+def fixed_border_msg(msg):
+    border = "="*51
+    result = border + "\n" + msg + "\n" + border
+    print(result)
+
+def get_linenumber():
+    cf = currentframe()
+    return cf.f_back.f_lineno
+
+# os.path.basename(__file__)
+def processCmd(cmd, lineNumber = 0, moduleNameWhereItsCalled = "", quiet = 0):
+    """This function is defined for processing of os command
+
+    Args:
+        cmd (str): The command to be run on the terminal
+        lineNumber (int): The line number from where this function was invoked
+        quiet (int, optional): Want to run the command in quite mode (Don't print anything) or print everything. Defaults to 0.
+
+    Raises:
+        RuntimeError: If the command failed then exit the program with exit code
+
+    Returns:
+        str: The full output of the command
+    """
+    output = '\n'
+    logger.info("="*51)
+    logger.info("[INFO]: Current working directory: {0}".format(os.getcwd()))
+    logger.info("[INFO]: {}#{} command:\n\t{}".format(moduleNameWhereItsCalled, lineNumber, cmd)) # FIXME: now its always take filename as `Utils.py`. It should take the file name from where its called.
+    p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, bufsize=-1)
+    for line in iter(p.stdout.readline, ''):
+        output=output+str(line)
+    p.stdout.close()
+
+    if p.wait() != 0:
+        raise RuntimeError("%r failed, exit status: %d" % (cmd, p.returncode))
+
+    if (not quiet):
+        print('Output:\n   [{}] \n'.format(output))
+    logger.info("="*51)
+
+    return output
+

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -40,7 +40,7 @@ def get_linenumber():
     cf = currentframe()
     return cf.f_back.f_lineno
 
-def processCmd(cmd, lineNumber, quiet = 0):
+def processCmd(cmd, lineNumber = 0, quiet = 0):
     """This function is defined for processing of os command
 
     Args:
@@ -57,7 +57,7 @@ def processCmd(cmd, lineNumber, quiet = 0):
     output = '\n'
     print("="*51)
     print("[INFO]: Current working directory: {0}".format(os.getcwd()))
-    print("[INFO]: {}#{} command:\n\t{}".format(os.path.basename(__file__), lineNumber, cmd))
+    print("[INFO]: {}#{} command:\n\t{}".format(os.path.basename(__file__), lineNumber, cmd)) # FIXME: now its always take filename as `Utils.py`. It should take the file name from where its called.
     p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, bufsize=-1)
     for line in iter(p.stdout.readline, ''):
         output=output+str(line)
@@ -68,6 +68,7 @@ def processCmd(cmd, lineNumber, quiet = 0):
 
     if (not quiet):
         print ('Output:\n   [{}] \n'.format(output))
+    print("="*51)
 
     return output
 
@@ -78,15 +79,15 @@ class ColorLogFormatter(logging.Formatter):
 
      # FORMAT = "%(prefix)s%(msg)s%(suffix)s"
     #  FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
-     FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s - %(message)s %(suffix)s\n"
+     FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(message)s %(suffix)s\n"
     #  FORMAT = "\n%(asctime)s - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
 
      LOG_LEVEL_COLOR = {
          "DEBUG": {'prefix': bcolors.OKBLUE, 'suffix': bcolors.ENDC},
          "INFO": {'prefix': bcolors.OKGREEN, 'suffix': bcolors.ENDC},
          "WARNING": {'prefix': bcolors.WARNING, 'suffix': bcolors.ENDC},
-         "ERROR": {'prefix': bcolors.FAIL+bcolors.BOLD, 'suffix': bcolors.ENDC+bcolors.ENDC},
          "CRITICAL": {'prefix': bcolors.FAIL, 'suffix': bcolors.ENDC},
+         "ERROR": {'prefix': bcolors.FAIL+bcolors.BOLD, 'suffix': bcolors.ENDC+bcolors.ENDC},
      }
 
      def format(self, record):

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -8,7 +8,7 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
-    
+
 
 def border_msg(msg):
     """Print message inside the border
@@ -24,7 +24,7 @@ def border_msg(msg):
     row = len(msg)+4
     h = ''.join(['+'] + ['-' *row] + ['+'])
     result= h + '\n'"|  "+msg+"  |"'\n' + h
-    print(result)
+    print(bcolors.OKGREEN + result +  bcolors.ENDC)
 
 def fixed_border_msg(msg):
     border = "="*51

--- a/python/Utils.py
+++ b/python/Utils.py
@@ -79,7 +79,9 @@ class ColorLogFormatter(logging.Formatter):
 
      # FORMAT = "%(prefix)s%(msg)s%(suffix)s"
     #  FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
-     FORMAT = "\n[%(levelname)s] - [%(filename)s:#%(lineno)d] - %(prefix)s%(message)s %(suffix)s\n"
+     FORMAT = "\n{}[%(levelname)5s] - [%(filename)s:#%(lineno)d] - [%(funcName)s; %(module)s]{} - %(prefix)s%(message)s %(suffix)s\n".format(
+         bcolors.HEADER, bcolors.ENDC
+     )
     #  FORMAT = "\n%(asctime)s - [%(filename)s:#%(lineno)d] - %(prefix)s%(levelname)s - %(message)s %(suffix)s\n"
 
      LOG_LEVEL_COLOR = {

--- a/python/addConstrainedModel.py
+++ b/python/addConstrainedModel.py
@@ -6,6 +6,8 @@ from math import *
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
+from Utils import  logging, logger
+from read_bins import read_bins
 
 grootargs = []
 def callback_rootargs(option, opt, value, parser):
@@ -30,6 +32,7 @@ def parseOptions():
     parser.add_option("-l",action="callback",callback=callback_rootargs)
     parser.add_option("-q",action="callback",callback=callback_rootargs)
     parser.add_option("-b",action="callback",callback=callback_rootargs)
+    parser.add_option("", "--logLevel", action="store", dest="logLevel", help="Change log verbosity(WARNING: 0, INFO: 1, DEBUG: 2)")
 
     # store options and arguments as global variables
     global opt, args
@@ -40,15 +43,24 @@ global opt, args, runAllSteps
 parseOptions()
 sys.argv = grootargs
 
+log_level = logging.DEBUG # default initialization
+if opt.logLevel == "0":
+    log_level = logging.WARNING
+elif opt.logLevel == "1":
+    log_level = logging.INFO
+elif opt.logLevel == "2":
+    log_level = logging.DEBUG
+logger.setLevel( log_level)
+
 sys.path.append('./'+datacardInputs)
+
 obsName = opt.OBSNAME
-
 observableBins = opt.OBSBINS
-observableBins = observableBins.split('|')
-observableBins.pop()
-observableBins.pop(0)
+# observableBins = observableBins.split('|')
+# observableBins.pop()
+# observableBins.pop(0)
 
-_temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
+_temp = __import__('inputs_sig_'+obsName.replace(' ','_'), globals(), locals(), ['acc','dacc','eff','deff','inc_outfrac','binfrac_outfrac','outinratio','doutinratio','inc_wrongfrac','binfrac_wrongfrac','cfactor','lambdajesup','lambdajesdn'], -1)
 print('inputs_sig_'+obsName)
 acc = _temp.acc
 dacc = _temp.dacc
@@ -77,14 +89,20 @@ for fState in fStates:
     upfactors_diag = {}
     dnfactors_diag = {}
 
-    for recobin in range(len(observableBins)-1):
+    binDetails = read_bins(observableBins)
+    logger.info(binDetails)
 
-        fout_ggH = max(outinratio['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
-        #fout_ggH = max(outinratio['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
-        fout_VBF = max(outinratio['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
-        fout_WH = max(outinratio['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
-        fout_ZH = max(outinratio['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
-        fout_ttH = max(outinratio['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
+    binSize = len(binDetails) if ('vs' in opt.OBSNAME) else len(binDetails) -1
+    logger.info("Bin size = "+str(binSize))
+
+    for recobin in range(binSize):
+
+        fout_ggH = max(outinratio['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
+        #fout_ggH = max(outinratio['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
+        fout_VBF = max(outinratio['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
+        fout_WH = max(outinratio['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
+        fout_ZH = max(outinratio['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
+        fout_ttH = max(outinratio['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)],0.0)
 
         ggHxs_allgen=0.0
         VBFxs_allgen=0.0
@@ -92,13 +110,14 @@ for fState in fStates:
         ZHxs_allgen=0.0
         ttHxs_allgen=0.0
 
-        for genbin in range(len(observableBins)-1):
-            ggHxs_allgen += higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            #ggHxs_allgen += acc['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            VBFxs_allgen += higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            WHxs_allgen += higgs_xs['WH_125.0']*higgs4l_br['125.0_'+fState]*acc['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            ZHxs_allgen += higgs_xs['ZH_125.0']*higgs4l_br['125.0_'+fState]*acc['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            ttHxs_allgen += higgs_xs['ttH_125.0']*higgs4l_br['125.0_'+fState]*acc['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+        for genbin in range(binSize):
+            logger.debug("(recobin, genbin): ("+str(recobin) + ', '+str(genbin)+')')
+            ggHxs_allgen += higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            #ggHxs_allgen += acc['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            VBFxs_allgen += higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            WHxs_allgen += higgs_xs['WH_125.0']*higgs4l_br['125.0_'+fState]*acc['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            ZHxs_allgen += higgs_xs['ZH_125.0']*higgs4l_br['125.0_'+fState]*acc['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            ttHxs_allgen += higgs_xs['ttH_125.0']*higgs4l_br['125.0_'+fState]*acc['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
 
         outin_SM = ggHxs_allgen*fout_ggH/(ggHxs_allgen+VBFxs_allgen+WHxs_allgen+ZHxs_allgen+ttHxs_allgen)
         outin_SM += VBFxs_allgen*fout_VBF/(ggHxs_allgen+VBFxs_allgen+WHxs_allgen+ZHxs_allgen+ttHxs_allgen)
@@ -106,25 +125,26 @@ for fState in fStates:
         outin_SM += ZHxs_allgen*fout_ZH/(ggHxs_allgen+VBFxs_allgen+WHxs_allgen+ZHxs_allgen+ttHxs_allgen)
         outin_SM += ttHxs_allgen*fout_ttH/(ggHxs_allgen+VBFxs_allgen+WHxs_allgen+ZHxs_allgen+ttHxs_allgen)
 
-        for genbin in range(len(observableBins)-1):
+        for genbin in range(binSize):
+            logger.debug("(recobin, genbin): ("+str(recobin) + ', '+str(genbin)+')')
 
-            ggHxs = higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            #ggHxs = acc['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            VBFxs = higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            WHxs = higgs_xs['WH_125.0']*higgs4l_br['125.0_'+fState]*acc['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            ZHxs = higgs_xs['ZH_125.0']*higgs4l_br['125.0_'+fState]*acc['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-            ttHxs = higgs_xs['ttH_125.0']*higgs4l_br['125.0_'+fState]*acc['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            ggHxs = higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            #ggHxs = acc['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            VBFxs = higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            WHxs = higgs_xs['WH_125.0']*higgs4l_br['125.0_'+fState]*acc['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            ZHxs = higgs_xs['ZH_125.0']*higgs4l_br['125.0_'+fState]*acc['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+            ttHxs = higgs_xs['ttH_125.0']*higgs4l_br['125.0_'+fState]*acc['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
 
 
-            effsm = ggHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-            #effsm = ggHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-            effsm += VBFxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-            effsm += WHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-            effsm += ZHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-            effsm += ttHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+            effsm = ggHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+            #effsm = ggHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+            effsm += VBFxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+            effsm += WHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+            effsm += ZHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+            effsm += ttHxs/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)*max(eff['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
 
-            eff['SM_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = effsm
-            outinratio['SM_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = outin_SM
+            eff['SM_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = effsm
+            outinratio['SM_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = outin_SM
 
             effUp = effsm
             effDn = effsm
@@ -167,12 +187,12 @@ for fState in fStates:
                                 if ("jet" in obsName): f_ttH = 0.0
                                 if (f_ggH+f_VBF+f_WH+f_ZH+f_ttH <0.00001): continue
 
-                                tmp_eff = f_ggH*ggHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-                                #tmp_eff = f_ggH*ggHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-                                tmp_eff += f_VBF*VBFxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-                                tmp_eff += f_WH*WHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-                                tmp_eff += f_ZH*ZHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
-                                tmp_eff += f_ttH*ttHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+                                tmp_eff = f_ggH*ggHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+                                #tmp_eff = f_ggH*ggHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+                                tmp_eff += f_VBF*VBFxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+                                tmp_eff += f_WH*WHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+                                tmp_eff += f_ZH*ZHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
+                                tmp_eff += f_ttH*ttHxs/(f_ggH*ggHxs+f_VBF*VBFxs+f_WH*WHxs+f_ZH*ZHxs+f_ttH*ttHxs)*max(eff['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)],0.0)
 
                                 tmp_outin = f_ggH*ggHxs_allgen*fout_ggH/(f_ggH*ggHxs_allgen+f_VBF*VBFxs_allgen+f_WH*WHxs_allgen+f_ZH*ZHxs_allgen+f_ttH*ttHxs_allgen)
                                 tmp_outin += f_VBF*VBFxs_allgen*fout_VBF/(f_ggH*ggHxs_allgen+f_VBF*VBFxs_allgen+f_WH*WHxs_allgen+f_ZH*ZHxs_allgen+f_ttH*ttHxs_allgen)
@@ -215,56 +235,56 @@ for fState in fStates:
 
 
 
-            eff['SMup_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = effUp
-            eff['SMdn_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = effDn
-            outinratio['SMup_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = outinUp
-            outinratio['SMdn_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = outinDn
+            eff['SMup_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = effUp
+            eff['SMdn_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = effDn
+            outinratio['SMup_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = outinUp
+            outinratio['SMdn_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)] = outinDn
 
 
-            #print fState,obsName,'genbin',str(genbin),'recobin',str(recobin),'effsm',effsm,'effUp',effUp,'effDn',effDn,'outinSM',outin_SM,'outinUp',outinUp,'outinDn',outinDn
+            #print fState,obsName.replace(' ','_'),'genbin',str(genbin),'recobin',str(recobin),'effsm',effsm,'effUp',effUp,'effDn',effDn,'outinSM',outin_SM,'outinUp',outinUp,'outinDn',outinDn
             #if (effsm>0.0):
             #    print '(1-fout)/eff SM:',(1.0-outin_SM)/effsm,'(1-fout)/eff SMup',(1.0-outinUp)/effUp,'(1-fout)/eff SMdn',(1.0-outinDn)/effDn
             #print 'dnfactors',upfactors,'dnfactors',dnfactors
 
 
-    for recobin in range(len(observableBins)-1):
+    for recobin in range(binSize):
 
-        jesSM = ggHxs*(1.0+lambdajesup['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
-        #jesSM = ggHxs*(1.0+lambdajesup['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
-        jesSM += VBFxs*(1.0+lambdajesup['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
-        jesSM += WHxs*(1.0+lambdajesup['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
-        jesSM += ZHxs*(1.0+lambdajesup['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
-        jesSM += ttHxs*(1.0+lambdajesup['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
+        jesSM = ggHxs*(1.0+lambdajesup['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
+        #jesSM = ggHxs*(1.0+lambdajesup['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
+        jesSM += VBFxs*(1.0+lambdajesup['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
+        jesSM += WHxs*(1.0+lambdajesup['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
+        jesSM += ZHxs*(1.0+lambdajesup['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
+        jesSM += ttHxs*(1.0+lambdajesup['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(recobin)])/(ggHxs+VBFxs+WHxs+ZHxs+ttHxs)
         jesSM = jesSM-1.0
-        lambdajesup['SM_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)] = jesSM
+        lambdajesup['SM_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)] = jesSM
 
 
-        jesSMup = upfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
-        #jesSMup = upfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
-        jesSMup += upfactors_diag['VBF']*VBFxs*(1.0+lambdajesup['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
-        jesSMup += upfactors_diag['WH']*WHxs*(1.0+lambdajesup['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
-        jesSMup += upfactors_diag['ZH']*ZHxs*(1.0+lambdajesup['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
-        jesSMup += upfactors_diag['ttH']*ttHxs*(1.0+lambdajesup['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
+        jesSMup = upfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
+        #jesSMup = upfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
+        jesSMup += upfactors_diag['VBF']*VBFxs*(1.0+lambdajesup['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
+        jesSMup += upfactors_diag['WH']*WHxs*(1.0+lambdajesup['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
+        jesSMup += upfactors_diag['ZH']*ZHxs*(1.0+lambdajesup['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
+        jesSMup += upfactors_diag['ttH']*ttHxs*(1.0+lambdajesup['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(upfactors_diag['ggH']*ggHxs+upfactors_diag['VBF']*VBFxs+upfactors_diag['WH']*WHxs+upfactors_diag['ZH']*ZHxs+upfactors_diag['ttH']*ttHxs)
         jesSMup = jesSMup-1.0
-        lambdajesup['SMup_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)] = jesSMup
+        lambdajesup['SMup_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)] = jesSMup
 
 
         #print upfactors_diag
         #print dnfactors_diag
 
-        #jesSMdn = dnfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
-        jesSMdn = dnfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
-        jesSMdn += dnfactors_diag['VBF']*VBFxs*(1.0+lambdajesup['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
-        jesSMdn += dnfactors_diag['WH']*WHxs*(1.0+lambdajesup['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
-        jesSMdn += dnfactors_diag['ZH']*ZHxs*(1.0+lambdajesup['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
-        jesSMdn += dnfactors_diag['ttH']*ttHxs*(1.0+lambdajesup['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
+        #jesSMdn = dnfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
+        jesSMdn = dnfactors_diag['ggH']*ggHxs*(1.0+lambdajesup['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
+        jesSMdn += dnfactors_diag['VBF']*VBFxs*(1.0+lambdajesup['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
+        jesSMdn += dnfactors_diag['WH']*WHxs*(1.0+lambdajesup['WH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
+        jesSMdn += dnfactors_diag['ZH']*ZHxs*(1.0+lambdajesup['ZH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
+        jesSMdn += dnfactors_diag['ttH']*ttHxs*(1.0+lambdajesup['ttH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)])/(dnfactors_diag['ggH']*ggHxs+dnfactors_diag['VBF']*VBFxs+dnfactors_diag['WH']*WHxs+dnfactors_diag['ZH']*ZHxs+dnfactors_diag['ttH']*ttHxs)
         jesSMdn = jesSMdn-1.0
-        lambdajesup['SMdn_125_'+fState+'_'+obsName+'_genbin'+str(recobin)+'_recobin'+str(recobin)] = jesSMdn
+        lambdajesup['SMdn_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(recobin)+'_recobin'+str(recobin)] = jesSMdn
 
 
-        print fState,obsName,'recobin',str(recobin),'jesSM',jesSM,'jesSMup',jesSMup,'jesSMdn',jesSMdn
+        print fState,obsName.replace(' ','_'),'recobin',str(recobin),'jesSM',jesSM,'jesSMup',jesSMup,'jesSMdn',jesSMdn
 
-with open(datacardInputs+'/inputs_sig_'+opt.OBSNAME+'.py', 'w') as f:
+with open(datacardInputs+'/inputs_sig_'+(opt.OBSNAME).replace(' ','_')+'.py', 'w') as f:
     f.write('acc = '+str(acc)+' \n')
     f.write('dacc = '+str(dacc)+' \n')
     f.write('eff = '+str(eff)+' \n')
@@ -278,6 +298,3 @@ with open(datacardInputs+'/inputs_sig_'+opt.OBSNAME+'.py', 'w') as f:
     f.write('cfactor = '+str(cfactor)+' \n')
     f.write('lambdajesup = '+str(lambdajesup)+' \n')
     f.write('lambdajesdn = '+str(lambdajesdn)+' \n')
-
-
-

--- a/python/addConstrainedModel.py
+++ b/python/addConstrainedModel.py
@@ -90,9 +90,9 @@ for fState in fStates:
     dnfactors_diag = {}
 
     binDetails = read_bins(observableBins)
-    logger.info(binDetails)
+    logger.info("bins: {}".format(binDetails))
 
-    binSize = len(binDetails) if ('vs' in opt.OBSNAME) else len(binDetails) -1
+    binSize = len(binDetails) if ('vs' in obsName) else len(binDetails) -1
     logger.info("Bin size = "+str(binSize))
 
     for recobin in range(binSize):
@@ -111,7 +111,7 @@ for fState in fStates:
         ttHxs_allgen=0.0
 
         for genbin in range(binSize):
-            logger.debug("(recobin, genbin): ("+str(recobin) + ', '+str(genbin)+')')
+            # logger.debug("(recobin, genbin): ("+str(recobin) + ', '+str(genbin)+')')
             ggHxs_allgen += higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
             #ggHxs_allgen += acc['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
             VBFxs_allgen += higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
@@ -126,7 +126,7 @@ for fState in fStates:
         outin_SM += ttHxs_allgen*fout_ttH/(ggHxs_allgen+VBFxs_allgen+WHxs_allgen+ZHxs_allgen+ttHxs_allgen)
 
         for genbin in range(binSize):
-            logger.debug("(recobin, genbin): ("+str(recobin) + ', '+str(genbin)+')')
+            # logger.debug("(recobin, genbin): ("+str(recobin) + ', '+str(genbin)+')')
 
             ggHxs = higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
             #ggHxs = acc['ggH_HRes_125_'+fState+'_'+obsName.replace(' ','_')+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
@@ -284,7 +284,7 @@ for fState in fStates:
 
         print fState,obsName.replace(' ','_'),'recobin',str(recobin),'jesSM',jesSM,'jesSMup',jesSMup,'jesSMdn',jesSMdn
 
-with open(datacardInputs+'/inputs_sig_'+(opt.OBSNAME).replace(' ','_')+'.py', 'w') as f:
+with open(datacardInputs+'/inputs_sig_'+(obsName).replace(' ','_')+'.py', 'w') as f:
     f.write('acc = '+str(acc)+' \n')
     f.write('dacc = '+str(dacc)+' \n')
     f.write('eff = '+str(eff)+' \n')

--- a/python/collectInputs.py
+++ b/python/collectInputs.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 # INFO: Following items are imported from either python directory or Inputs
-from Input_Info import *
+from Input_Info import datacardInputs
 
 sys.path.append('./'+datacardInputs)
 

--- a/python/collectInputs.py
+++ b/python/collectInputs.py
@@ -30,8 +30,8 @@ def collect(obsName):
 	if (obsName=='mass4l'): channels.append('4l')
 
 	for ch in channels:
-		border_msg("module to import: "+'inputs_sig_'+obsName+'_'+ch+".py")
-		_tmp = __import__('inputs_sig_'+obsName+'_'+ch, globals(), locals(), -1)
+		border_msg("module to import: "+'inputs_sig_'+obsName.replace(' ','_')+'_'+ch+".py")
+		_tmp = __import__('inputs_sig_'+obsName.replace(' ','_')+'_'+ch, globals(), locals(), -1)
 
 		acc.update(_tmp.acc)
 		dacc.update(_tmp.dacc)

--- a/python/collectInputs.py
+++ b/python/collectInputs.py
@@ -9,15 +9,15 @@ sys.path.append('./'+datacardInputs)
 def collect(obsName):
 
 	acc = {}
-	dacc = {} 
-	acc_4l = {} 
+	dacc = {}
+	acc_4l = {}
 	dacc_4l = {}
 	dacc_4l = {}
 	eff = {}
 	deff = {}
 	inc_outfrac = {}
 	binfrac_outfrac = {}
-	outinratio = {} 
+	outinratio = {}
 	doutinratio = {}
 	inc_wrongfrac = {}
 	binfrac_wrongfrac = {}
@@ -29,7 +29,7 @@ def collect(obsName):
 	if (obsName=='mass4l'): channels.append('4l')
 
 	for ch in channels:
-		_tmp = __import__('inputs_sig_'+obsName+'_'+ch, globals(), locals(), -1)
+		_tmp = __import__('inputs_sig_'+obsName.replace(" ","_")+'_'+ch, globals(), locals(), -1)
 
 		acc.update(_tmp.acc)
 		dacc.update(_tmp.dacc)
@@ -47,7 +47,7 @@ def collect(obsName):
 		lambdajesup.update(_tmp.lambdajesup)
 		lambdajesdn.update(_tmp.lambdajesdn)
 
-	with open(datacardInputs+'/inputs_sig_'+obsName+'.py', 'w') as f:
+	with open(datacardInputs+'/inputs_sig_'+obsName.replace(" ","_")+'.py', 'w') as f:
 		f.write('acc = '+str(acc)+' \n')
 		f.write('dacc = '+str(dacc)+' \n')
 		f.write('acc_4l = '+str(acc_4l)+' \n')

--- a/python/createXSworkspace.py
+++ b/python/createXSworkspace.py
@@ -19,7 +19,7 @@ from ROOT import *
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
-from Utils import  logging, logger
+from Utils import  logger
 
 sys.path.append('./'+datacardInputs)
 
@@ -39,7 +39,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         modelName (str): Name of model. For example "SM_125"
         physicalModel (str): physical model. For example: "v2"
     """
-    logger.info("""Input arguments:
+    logger.info("""Input arguments to createXSworkspace module:
         obsName: {obsName}
         obsType: {obsType}
         channel: {channel}
@@ -69,10 +69,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         is2DObs = True
         logger.info("This is recognised as 2D observable...")
         obsNameDictKey = obsNameOrig[0]+'_vs_'+obsNameOrig[1]   # Update the dict key
-        logger.error("observable name: {}".format(obsNameOrig))
-        logger.error("observable bin: {}".format(observableBins[obsBin]))
-        logger.error("observable bin 0: {}".format(observableBins[obsBin][0]))
-        logger.error("observable bin 1: {}".format(observableBins[obsBin][1]))
+        logger.debug("observable bin - {} - : {}".format(obsBin, observableBins[obsBin]))
 
         obsBin_low = observableBins[obsBin][0][0]
         obsBin_high = observableBins[obsBin][0][1]
@@ -87,22 +84,20 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
                     obsBin_low, obsBin_high, obs_bin_lowest, obs_bin_highest
                     ))
         SuffixOfRootFile = obsNameOrig[0]+"_"+obsBin_low+"_"+obsBin_high
-        logger.info("SuffixOfRootFile: {}".format(SuffixOfRootFile))
+        logger.debug("SuffixOfRootFile: {}".format(SuffixOfRootFile))
 
         obsBin_low2 = observableBins[obsBin][1][0]
         obsBin_high2 = observableBins[obsBin][1][1]
 
         obs_bin_lowest2 = min(observableBins[obsBin][1])
         obs_bin_highest2 = max(observableBins[obsBin][1])
-        logger.info("obsBin_low2: {}".format(obsBin_low2))
-        logger.info("obsBin_high2: {}".format(obsBin_high2))
-        SuffixOfRootFile = SuffixOfRootFile + '_' + obsNameOrig[1] + "_" + obsBin_low2 + "_" + obsBin_high2
-        logger.info("SuffixOfRootFile: {}".format(SuffixOfRootFile))
         logger.debug("""
                 (obsBin_low2, obsBin_high2) = ({},{});
                 (obs_bin_lowest2, obs_bin_highest2) = ({}, {})""".format(
                     obsBin_low2, obsBin_high2, obs_bin_lowest2, obs_bin_highest2
                     ))
+        SuffixOfRootFile = SuffixOfRootFile + '_' + obsNameOrig[1] + "_" + obsBin_low2 + "_" + obsBin_high2
+        logger.debug("SuffixOfRootFile: {}".format(SuffixOfRootFile))
     else:
         logger.info("This is recognised as 1D observable...")
         # obsNameOrig = obsName
@@ -171,7 +166,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     # 4 lepton mass observable to perform the fit
     m = w.var("CMS_zz4l_mass")
     # m = RooRealVar("CMS_zz4l_mass", "CMS_zz4l_mass", 105.0, 140.0)
-    #print "m.numBins()",m.numBins()
+    #logger.info("m.numBins()",m.numBins())
     m.setMin(105.0)
     m.setMax(140.0)
     #m.setBins(45)
@@ -220,7 +215,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     # ZH_norm = RooRealVar("ZH_norm","ZH_norm", 0.157008222773) # FIXME: got these values from 8TeV Rootfiles
     # ttH_norm = RooRealVar("ttH_norm","ttH_norm", 0.03604907196) # FIXME: got these values from 8TeV Rootfiles
     n_allH = (ggH_norm.getVal()+qqH_norm.getVal()+WH_norm.getVal()+ZH_norm.getVal()+ttH_norm.getVal())
-    print("\n[INFO] allH norm: {}".format(n_allH))
+    logger.info("allH norm: {}".format(n_allH))
 
     # true signal shape
     trueH = w.pdf("ggH")
@@ -366,8 +361,8 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         trueH_shape[genbin].SetName("trueH"+channel+"Bin"+str(genbin))
         if (usecfactor): fideff[genbin] = cfactor[modelName+"_"+channel+"_"+obsNameDictKey+"_genbin"+str(genbin)+"_"+recobin]
         else: fideff[genbin] = eff[modelName+"_"+channel+"_"+obsNameDictKey+"_genbin"+str(genbin)+"_"+recobin]
-        print("[INFO] fideff[genbin]: {}".format(fideff[genbin]))
-        print("[INFO] model name is   {}".format(modelName))
+        logger.info("fideff[genbin]: {}".format(fideff[genbin]))
+        logger.info("model name is   {}".format(modelName))
         fideff_var[genbin] = RooRealVar("effBin"+str(genbin)+"_"+recobin+"_"+channel,"effBin"+str(genbin)+"_"+recobin+"_"+channel, fideff[genbin]);
 
         if( not (obsName=='nJets' or ("jet" in obsName)) or (not doJES)) :
@@ -437,7 +432,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
                 trueH_norm_final[genbin] = RooFormulaVar("trueH"+channel+"Bin"+str(genbin)+recobin+"_final","@0*@1*@2", RooArgList(rBin_channel[str(genbin)], fideff_var[genbin],lumi))
 
     outin = outinratio[modelName+"_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
-    print("outin: obsBin: {:3}\t outin: {}".format(obsBin,outin))
+    logger.info("outin: obsBin: {:3}\t outin: {}".format(obsBin,outin))
     outin_var = RooRealVar("outfracBin_"+recobin+"_"+channel,"outfracBin_"+recobin+"_"+channel, outin);
     outin_var.setConstant(True)
     out_trueH_norm_args = RooArgList(outin_var)
@@ -463,11 +458,11 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     frac_ggzz = fractionsBackground[bkg_sample_tags['ggzz'][channel]+'_'+channel+'_'+obsNameDictKey+'_'+recobin]
     frac_ggzz_var = RooRealVar("frac_ggzz_"+recobin+"_"+channel,"frac_ggzz_"+recobin+"_"+channel, frac_ggzz);
 
-    print ("fractionsBackground:\n\t{}".format(fractionsBackground))
+    logger.info ("fractionsBackground:\n\t{}".format(fractionsBackground))
     frac_zjets = fractionsBackground[bkg_sample_tags['zjets'][channel]+"_AllChans_"+obsNameDictKey+'_'+recobin]
     frac_zjets_var = RooRealVar("frac_zjet_"+recobin+"_"+channel,"frac_zjet_"+recobin+"_"+channel, frac_zjets);
 
-    print ("obsBin: {obsBin:2}, frac_qqzz: {frac_qqzz:9}, frac_ggzz: {frac_ggzz:9}, frac_zjets: {frac_zjets:9}".format(
+    logger.info ("obsBin: {obsBin:2}, frac_qqzz: {frac_qqzz:9}, frac_ggzz: {frac_ggzz:9}, frac_zjets: {frac_zjets:9}".format(
         obsBin = obsBin, frac_qqzz = frac_qqzz, frac_ggzz = frac_ggzz, frac_zjets = frac_zjets
     ))
 
@@ -506,15 +501,15 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         template_zjetsName = "./templates/templatesXS/DTreeXS_"+obsNameDictKey+"/13TeV/XSBackground_ZJetsCR_"+channel+"_"+SuffixOfRootFile+".root"
     qqzzTempFile = TFile(template_qqzzName,"READ")
     qqzzTemplate = qqzzTempFile.Get("m4l_"+SuffixOfRootFile)
-    print('[INFO] qqZZ bins : {}, {}, {}'.format(qqzzTemplate.GetNbinsX(),qqzzTemplate.GetBinLowEdge(1),qqzzTemplate.GetBinLowEdge(qqzzTemplate.GetNbinsX()+1)))
+    logger.info('qqZZ bins : {}, {}, {}'.format(qqzzTemplate.GetNbinsX(),qqzzTemplate.GetBinLowEdge(1),qqzzTemplate.GetBinLowEdge(qqzzTemplate.GetNbinsX()+1)))
 
     ggzzTempFile = TFile(template_ggzzName,"READ")
     ggzzTemplate = ggzzTempFile.Get("m4l_"+SuffixOfRootFile)
-    print('[INFO] ggZZ bins : {}, {}, {}'.format(ggzzTemplate.GetNbinsX(),ggzzTemplate.GetBinLowEdge(1),ggzzTemplate.GetBinLowEdge(ggzzTemplate.GetNbinsX()+1)))
+    logger.info('ggZZ bins : {}, {}, {}'.format(ggzzTemplate.GetNbinsX(),ggzzTemplate.GetBinLowEdge(1),ggzzTemplate.GetBinLowEdge(ggzzTemplate.GetNbinsX()+1)))
 
     zjetsTempFile = TFile(template_zjetsName,"READ")
     zjetsTemplate = zjetsTempFile.Get("m4l_"+SuffixOfRootFile)
-    print('[INFO] zjets bins: {}, {}, {}'.format(zjetsTemplate.GetNbinsX(),zjetsTemplate.GetBinLowEdge(1),zjetsTemplate.GetBinLowEdge(zjetsTemplate.GetNbinsX()+1)))
+    logger.info('zjets bins: {}, {}, {}'.format(zjetsTemplate.GetNbinsX(),zjetsTemplate.GetBinLowEdge(1),zjetsTemplate.GetBinLowEdge(zjetsTemplate.GetNbinsX()+1)))
 
     binscale = 3 # FIXME: Why number 3 hardcoded?
     qqzzTemplateNew = TH1F("qqzzTemplateNew","qqzzTemplateNew",binscale*qqzzTemplate.GetNbinsX(),qqzzTemplate.GetBinLowEdge(1),qqzzTemplate.GetBinLowEdge(qqzzTemplate.GetNbinsX()+1))
@@ -569,7 +564,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     else:  data_obs_file = TFile('Inputs/data_13TeV.root') #FIXME: Want to keep this in Input directory or at the same place where all ntuples are stored
     data_obs_tree = data_obs_file.Get('passedEvents')
 
-    print ("[INFO] Obs name: {:11}  Bin (low, high) edge: ({}, {})".format(obsName,obsBin_low,obsBin_high))
+    logger.info ("Obs name: {:11}  Bin (low, high) edge: ({}, {})".format(obsName,obsBin_low,obsBin_high))
     if (obsName == "nJets"): obsName = "njets_reco_pt30_eta4p7"
     if (channel=='4mu'):
         if (obsName.startswith("mass4l")): data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4mu),"(mass4mu>105.0 && mass4mu<140.0)")
@@ -642,7 +637,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     getattr(wout,'import')(fakeH) # RooFit.Silence()
     getattr(wout,'import')(fakeH_norm) # RooFit.Silence()
 
-    #print "trueH norm: ",n_trueH,"fakeH norm:",n_fakeH
+    #logger.info("trueH norm: ",n_trueH,"fakeH norm:",n_fakeH)
     qqzzTemplatePdf.SetName("bkg_qqzz")
     qqzzTemplatePdf.Print("v")
     getattr(wout,'import')(qqzzTemplatePdf,RooFit.RecycleConflictNodes()) # RooFit.Silence()

--- a/python/createXSworkspace.py
+++ b/python/createXSworkspace.py
@@ -19,11 +19,14 @@ from ROOT import *
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
+from Utils import  logging, logger
 
 sys.path.append('./'+datacardInputs)
 
 def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfactor, addfakeH, modelName, physicalModel):
     """Create workspace
+    this script is called once for each reco bin (obsBin)
+    in each reco bin there are (nBins) signals (one for each gen bin)
 
     Args:
         obsName (str): Name of observable
@@ -36,14 +39,87 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         modelName (str): Name of model. For example "SM_125"
         physicalModel (str): physical model. For example: "v2"
     """
+    logger.info("""Input arguments:
+        obsName: {obsName}
+        obsType: {obsType}
+        channel: {channel}
+        nBins: {nBins}
+        obsBin: {obsBin}
+        observableBins: {observableBins}
+        usecfactor: {usecfactor}
+        addfakeH: {addfakeH}
+        modelName: {modelName}
+        physicalModel: {physicalModel}""".format(
+            obsName = obsName,
+            obsType = type(obsName),
+            channel = channel,
+            nBins = nBins,
+            obsBin = obsBin,
+            observableBins = observableBins,
+            usecfactor = usecfactor,
+            addfakeH = addfakeH,
+            modelName = modelName,
+            physicalModel = physicalModel
+        ))
+    is2DObs = False
+    obsNameOrig = obsName   # Save original list into new variable
+    obsName = obsName[0]    # get first observable to be used for both 1D or 2D
+    obsNameDictKey = obsName    # This saves key for 1D, if 2D update the key to be searched from dict
+    if len(obsNameOrig)>1:
+        is2DObs = True
+        logger.info("This is recognised as 2D observable...")
+        obsNameDictKey = obsNameOrig[0]+'_vs_'+obsNameOrig[1]   # Update the dict key
+        logger.error("observable name: {}".format(obsNameOrig))
+        logger.error("observable bin: {}".format(observableBins[obsBin]))
+        logger.error("observable bin 0: {}".format(observableBins[obsBin][0]))
+        logger.error("observable bin 1: {}".format(observableBins[obsBin][1]))
 
-    obsBin_low = observableBins[obsBin]
-    obsBin_high = observableBins[obsBin+1]
+        obsBin_low = observableBins[obsBin][0][0]
+        obsBin_high = observableBins[obsBin][0][1]
 
-    obs_bin_lowest = observableBins[0]
-    obs_bin_highest = observableBins[len(observableBins)-1]
+        obs_bin_lowest   =  min(observableBins[obsBin][0])
+        obs_bin_highest =  max(observableBins[obsBin][0])
 
-    recobin = "recobin"+str(obsBin)
+        recobin = "recobin"+str(obsBin)
+        logger.debug("""
+                (obsBin_low,  obsBin_high ) = ({},{});
+                (obs_bin_lowest,  obs_bin_highest ) = ({}, {})""".format(
+                    obsBin_low, obsBin_high, obs_bin_lowest, obs_bin_highest
+                    ))
+        SuffixOfRootFile = obsNameOrig[0]+"_"+obsBin_low+"_"+obsBin_high
+        logger.info("SuffixOfRootFile: {}".format(SuffixOfRootFile))
+
+        obsBin_low2 = observableBins[obsBin][1][0]
+        obsBin_high2 = observableBins[obsBin][1][1]
+
+        obs_bin_lowest2 = min(observableBins[obsBin][1])
+        obs_bin_highest2 = max(observableBins[obsBin][1])
+        logger.info("obsBin_low2: {}".format(obsBin_low2))
+        logger.info("obsBin_high2: {}".format(obsBin_high2))
+        SuffixOfRootFile = SuffixOfRootFile + '_' + obsNameOrig[1] + "_" + obsBin_low2 + "_" + obsBin_high2
+        logger.info("SuffixOfRootFile: {}".format(SuffixOfRootFile))
+        logger.debug("""
+                (obsBin_low2, obsBin_high2) = ({},{});
+                (obs_bin_lowest2, obs_bin_highest2) = ({}, {})""".format(
+                    obsBin_low2, obsBin_high2, obs_bin_lowest2, obs_bin_highest2
+                    ))
+    else:
+        logger.info("This is recognised as 1D observable...")
+        # obsNameOrig = obsName
+        obsBin_low = observableBins[obsBin]
+        obsBin_high = observableBins[obsBin+1]
+
+        obs_bin_lowest = observableBins[0]
+        obs_bin_highest = observableBins[len(observableBins)-1]
+
+        recobin = "recobin"+str(obsBin)
+        logger.debug("""
+                (obsBin_low,  obsBin_high ) = ({},{});
+                (obs_bin_lowest,  obs_bin_highest ) = ({}, {})""".format(
+                    obsBin_low, obsBin_high, obs_bin_lowest, obs_bin_highest
+                    ))
+        SuffixOfRootFile = obsNameOrig[0]+"_"+obsBin_low+"_"+obsBin_high
+        logger.info("SuffixOfRootFile: {}".format(SuffixOfRootFile))
 
     doJES = 1
 
@@ -62,7 +138,10 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         inc_outfrac = _temp.inc_outfrac
         binfrac_outfrac = _temp.binfrac_wrongfrac
     else:
-        _temp = __import__('inputs_sig_'+obsName, globals(), locals(), ['acc','eff','inc_wrongfrac','binfrac_wrongfrac','outinratio','lambdajesup','lambdajesdn'], -1)
+        ModuleToImport = 'inputs_sig_'+obsNameDictKey
+        logger.debug("Module to import: "+ModuleToImport)
+        _temp = __import__(ModuleToImport, globals(), locals(), ['acc','eff','inc_wrongfrac','binfrac_wrongfrac','outinratio','lambdajesup','lambdajesdn'], -1)
+
         acc = _temp.acc
         eff = _temp.eff
         outinratio = _temp.outinratio
@@ -73,7 +152,9 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     binfrac_wrongfrac = _temp.binfrac_wrongfrac
 
     #from inputs_bkg_{obsName} import fractionsBackground
-    _temp = __import__('inputs_bkg_'+obsName, globals(), locals(), ['fractionsBackground'], -1)
+    ModuleToImport = 'inputs_bkg_'+obsNameDictKey
+    logger.debug("Module to import: "+ModuleToImport)
+    _temp = __import__(ModuleToImport, globals(), locals(), ['fractionsBackground'], -1)
     fractionsBackground = _temp.fractionsBackground
 
     # Load the legacy f
@@ -89,6 +170,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
 
     # 4 lepton mass observable to perform the fit
     m = w.var("CMS_zz4l_mass")
+    # m = RooRealVar("CMS_zz4l_mass", "CMS_zz4l_mass", 105.0, 140.0)
     #print "m.numBins()",m.numBins()
     m.setMin(105.0)
     m.setMax(140.0)
@@ -99,12 +181,13 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     mass4mu = RooRealVar("mass4mu", "mass4mu", 105.0, 140.0)
     mass2e2mu = RooRealVar("mass2e2mu", "mass2e2mu",105.0, 140.0)
     if (not obsName=="mass4l"):
-        if (obsName=="rapidity4l" or obsName=="cosThetaStar" or obsName=="cosTheta1" or obsName=="cosTheta2" or obsName=="Phi" or obsName=="Phi1"):
-            observable = RooRealVar(obsName,obsName,-1.0*float(obs_bin_highest),float(obs_bin_highest))
-        else:
-            observable = RooRealVar(obsName,obsName,float(obs_bin_lowest),float(obs_bin_highest))
+        # if (obsName=="rapidity4l" or obsName=="cosThetaStar" or obsName=="cosTheta1" or obsName=="cosTheta2" or obsName=="Phi" or obsName=="Phi1"):
+            # observable = RooRealVar(obsName,obsName,-1.0*float(obs_bin_highest),float(obs_bin_highest))
+        observable   = RooRealVar(obsName,obsName,float(obs_bin_lowest),float(obs_bin_highest))
         observable.Print()
-
+        if is2DObs:
+            observable2 = RooRealVar(obsNameOrig[1],obsNameOrig[1],float(obs_bin_lowest2),float(obs_bin_highest2))
+            observable2.Print()
     # luminosity
     lumi = RooRealVar("lumi_13","lumi_13", 59.7) # FIXME: Lumi value is hardcoded
 
@@ -114,7 +197,28 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     WH_norm = w.function("WH_norm")
     ZH_norm = w.function("ZH_norm")
     ttH_norm = w.function("ttH_norm")
-
+    # logger.debug("""
+    #     Norm values:
+    #         ggH_norm = {}
+    #         qqH_norm = {}
+    #         WH_norm = {}
+    #         ZH_norm = {}
+    #         ttH_norm = {}
+    #         Total: n_allH = {}
+    # """.format(
+    #     ggH_norm.getVal(),
+    #     qqH_norm.getVal(),
+    #     WH_norm.getVal(),
+    #     ZH_norm.getVal(),
+    #     ttH_norm.getVal(),
+    #     ggH_norm.getVal() + qqH_norm.getVal() + WH_norm.getVal() + ZH_norm.getVal() + ttH_norm.getVal()
+    # ))
+    # logger.error("=="*51)
+    # ggH_norm = RooRealVar("ggH_norm","ggH_norm", 6.94202296623) # FIXME: got these values from 8TeV Rootfiles
+    # qqH_norm = RooRealVar("qqH_norm","qqH_norm", 0.633580595429) # FIXME: got these values from 8TeV Rootfiles
+    # WH_norm = RooRealVar("WH_norm","WH_norm", 0.209508946773) # FIXME: got these values from 8TeV Rootfiles
+    # ZH_norm = RooRealVar("ZH_norm","ZH_norm", 0.157008222773) # FIXME: got these values from 8TeV Rootfiles
+    # ttH_norm = RooRealVar("ttH_norm","ttH_norm", 0.03604907196) # FIXME: got these values from 8TeV Rootfiles
     n_allH = (ggH_norm.getVal()+qqH_norm.getVal()+WH_norm.getVal()+ZH_norm.getVal()+ttH_norm.getVal())
     print("\n[INFO] allH norm: {}".format(n_allH))
 
@@ -205,12 +309,12 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         p2_3_8 = RooFormulaVar("CMS_fakeH_p2_3_8","p2_3_8","0.72*@0-@1",RooArgList(p1_3_8,p3_3_8))
         fakeH = RooLandau("fakeH", "landau", m, p1_3_8, p2_3_8)
     if (addfakeH):
-        inc_wrongfrac_ggH=inc_wrongfrac["ggH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-        #inc_wrongfrac_ggH=inc_wrongfrac["ggH_HRes_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-        inc_wrongfrac_qqH=inc_wrongfrac["VBF_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-        inc_wrongfrac_WH=inc_wrongfrac["WH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-        inc_wrongfrac_ZH=inc_wrongfrac["ZH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-        inc_wrongfrac_ttH=inc_wrongfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
+        inc_wrongfrac_ggH=inc_wrongfrac["ggH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+        #inc_wrongfrac_ggH=inc_wrongfrac["ggH_HRes_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+        inc_wrongfrac_qqH=inc_wrongfrac["VBF_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+        inc_wrongfrac_WH=inc_wrongfrac["WH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+        inc_wrongfrac_ZH=inc_wrongfrac["ZH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+        inc_wrongfrac_ttH=inc_wrongfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
     else:
         inc_wrongfrac_ggH=0.0
         inc_wrongfrac_qqH=0.0
@@ -218,12 +322,12 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         inc_wrongfrac_ZH=0.0
         inc_wrongfrac_ttH=0.0
 
-    binfrac_wrongfrac_ggH=binfrac_wrongfrac["ggH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #binfrac_wrongfrac_ggH=binfrac_wrongfrac["ggH_HRes_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    binfrac_wrongfrac_qqH=binfrac_wrongfrac["VBF_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    binfrac_wrongfrac_WH=binfrac_wrongfrac["WH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    binfrac_wrongfrac_ZH=binfrac_wrongfrac["ZH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    binfrac_wrongfrac_ttH=binfrac_wrongfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
+    binfrac_wrongfrac_ggH=binfrac_wrongfrac["ggH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+    #binfrac_wrongfrac_ggH=binfrac_wrongfrac["ggH_HRes_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+    binfrac_wrongfrac_qqH=binfrac_wrongfrac["VBF_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+    binfrac_wrongfrac_WH=binfrac_wrongfrac["WH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+    binfrac_wrongfrac_ZH=binfrac_wrongfrac["ZH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
+    binfrac_wrongfrac_ttH=binfrac_wrongfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
 
     if (channel=='4e'):
         # FIXME: Check these values
@@ -241,30 +345,6 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     # (same shape as in acceptance shape)
     out_trueH = trueH.Clone()
 
-    #if (not usecfactor):
-    #    inc_outfrac_ggH=inc_outfrac["ggH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    inc_outfrac_qqH=inc_outfrac["VBF_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    inc_outfrac_WH=inc_outfrac["WH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    inc_outfrac_ZH=inc_outfrac["ZH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    inc_outfrac_ttH=inc_outfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-
-    #    binfrac_outfrac_ggH=binfrac_outfrac["ggH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    binfrac_outfrac_qqH=binfrac_outfrac["VBF_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    binfrac_outfrac_WH=binfrac_outfrac["WH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    binfrac_outfrac_ZH=binfrac_outfrac["ZH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-    #    binfrac_outfrac_ttH=binfrac_outfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
-
-    #    n_out_trueH =  binfrac_outfrac_ggH*inc_outfrac_ggH*(1.0-inc_wrongfrac_ggH)*ggH_norm.getVal()
-    #    n_out_trueH += binfrac_outfrac_qqH*inc_outfrac_qqH*(1.0-inc_wrongfrac_qqH)*qqH_norm.getVal()
-    #    n_out_trueH += binfrac_outfrac_WH*inc_outfrac_WH*(1.0-inc_wrongfrac_WH)*WH_norm.getVal()
-    #    n_out_trueH += binfrac_outfrac_ZH*inc_outfrac_ZH*(1.0-inc_wrongfrac_ZH)*ZH_norm.getVal()
-    #    n_out_trueH += binfrac_outfrac_ttH*inc_outfrac_ttH*(1.0-inc_wrongfrac_ttH)*ttH_norm.getVal()
-    #    n_out_trueH_var = RooRealVar("n_out_trueH_var_"+recobin+"_"+channel, "n_out_trueH_var_"+recobin+"_"+channel, n_out_trueH);
-
-    #n_trueH = binfrac_true_ggH*(1.0-inc_outfrac_ggH)*(1.0-inc_wrongfrac_ggH)*ggH_norm.getVal()
-    #n_trueH_var = RooRealVar("n_fakeH_var_"+recobin+"_"+channel,"n_fakeH_var_"+recobin+"_"+channel,n_fakeH);
-    #trueH_norm = RooFormulaVar("fakeH_norm","@0",RooArgList(n_fakeH_var))
-
     # true signal shape/norm
     trueH = w.pdf("ggH")
 
@@ -281,11 +361,11 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         lambda_JES_sig_var = RooRealVar("lambda_sig_"+modelName+"_"+channel+"_"+obsName+"_genbin"+str(obsBin)+""+"_"+recobin, "lambda_sig_"+modelName+"_"+channel+"_"+obsName+"_genbin"+str(obsBin)+""+"_"+recobin, lambda_JES_sig)
         JES_sig_rfv = RooFormulaVar("JES_rfv_sig_"+recobin+"_"+channel,"@0*@1", RooArgList(JES, lambda_JES_sig_var) )
 
-    for genbin in range(nBins-1):
+    for genbin in range(nBins):
         trueH_shape[genbin] = trueH.Clone();
         trueH_shape[genbin].SetName("trueH"+channel+"Bin"+str(genbin))
-        if (usecfactor): fideff[genbin] = cfactor[modelName+"_"+channel+"_"+obsName+"_genbin"+str(genbin)+"_"+recobin]
-        else: fideff[genbin] = eff[modelName+"_"+channel+"_"+obsName+"_genbin"+str(genbin)+"_"+recobin]
+        if (usecfactor): fideff[genbin] = cfactor[modelName+"_"+channel+"_"+obsNameDictKey+"_genbin"+str(genbin)+"_"+recobin]
+        else: fideff[genbin] = eff[modelName+"_"+channel+"_"+obsNameDictKey+"_genbin"+str(genbin)+"_"+recobin]
         print("[INFO] fideff[genbin]: {}".format(fideff[genbin]))
         print("[INFO] model name is   {}".format(modelName))
         fideff_var[genbin] = RooRealVar("effBin"+str(genbin)+"_"+recobin+"_"+channel,"effBin"+str(genbin)+"_"+recobin+"_"+channel, fideff[genbin]);
@@ -307,7 +387,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     SigmaBin = {}
     SigmaHBin = {}
 
-    for genbin in range(nBins-1):
+    for genbin in range(nBins):
         if (physicalModel=="v3"):
             fidxs = {}
             for fState in ['4e','4mu', '2e2mu']:
@@ -356,16 +436,16 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
             else:
                 trueH_norm_final[genbin] = RooFormulaVar("trueH"+channel+"Bin"+str(genbin)+recobin+"_final","@0*@1*@2", RooArgList(rBin_channel[str(genbin)], fideff_var[genbin],lumi))
 
-    outin = outinratio[modelName+"_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
+    outin = outinratio[modelName+"_"+channel+"_"+obsNameDictKey+"_genbin"+str(obsBin)+"_"+recobin]
     print("outin: obsBin: {:3}\t outin: {}".format(obsBin,outin))
     outin_var = RooRealVar("outfracBin_"+recobin+"_"+channel,"outfracBin_"+recobin+"_"+channel, outin);
     outin_var.setConstant(True)
     out_trueH_norm_args = RooArgList(outin_var)
     out_trueH_norm_func = "@0*("
-    for i in range(nBins-1):
+    for i in range(nBins):
         out_trueH_norm_args.add(trueH_norm_final[i])
         out_trueH_norm_func = out_trueH_norm_func+"@"+str(i+1)+"+"
-    out_trueH_norm_func = out_trueH_norm_func.replace(str(nBins-1)+"+",str(nBins-1)+")")
+    out_trueH_norm_func = out_trueH_norm_func.replace(str(nBins)+"+",str(nBins)+")")
     out_trueH_norm = RooFormulaVar("out_trueH_norm",out_trueH_norm_func,out_trueH_norm_args)
 
     # Backgrounds
@@ -377,14 +457,14 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     bkg_sample_tags = { 'qqzz':{'2e2mu':'ZZTo2e2mu_powheg', '4e':'ZZTo4e_powheg', '4mu':'ZZTo4mu_powheg'},
                         'ggzz':{'2e2mu':'ggZZ_2e2mu_MCFM67', '4e':'ggZZ_4e_MCFM67', '4mu':'ggZZ_4mu_MCFM67'},
                         'zjets':{'2e2mu':'ZX4l_CR', '4e':'ZX4l_CR', '4mu':'ZX4l_CR'}}
-    frac_qqzz = fractionsBackground[bkg_sample_tags['qqzz'][channel]+'_'+channel+'_'+obsName+'_'+recobin]
+    frac_qqzz = fractionsBackground[bkg_sample_tags['qqzz'][channel]+'_'+channel+'_'+obsNameDictKey+'_'+recobin]
     frac_qqzz_var  = RooRealVar("frac_qqzz_"+recobin+"_"+channel,"frac_qqzz_"+recobin+"_"+channel, frac_qqzz);
 
-    frac_ggzz = fractionsBackground[bkg_sample_tags['ggzz'][channel]+'_'+channel+'_'+obsName+'_'+recobin]
+    frac_ggzz = fractionsBackground[bkg_sample_tags['ggzz'][channel]+'_'+channel+'_'+obsNameDictKey+'_'+recobin]
     frac_ggzz_var = RooRealVar("frac_ggzz_"+recobin+"_"+channel,"frac_ggzz_"+recobin+"_"+channel, frac_ggzz);
 
     print ("fractionsBackground:\n\t{}".format(fractionsBackground))
-    frac_zjets = fractionsBackground[bkg_sample_tags['zjets'][channel]+"_AllChans_"+obsName+'_'+recobin]
+    frac_zjets = fractionsBackground[bkg_sample_tags['zjets'][channel]+"_AllChans_"+obsNameDictKey+'_'+recobin]
     frac_zjets_var = RooRealVar("frac_zjet_"+recobin+"_"+channel,"frac_zjet_"+recobin+"_"+channel, frac_zjets);
 
     print ("obsBin: {obsBin:2}, frac_qqzz: {frac_qqzz:9}, frac_ggzz: {frac_ggzz:9}, frac_zjets: {frac_zjets:9}".format(
@@ -417,23 +497,23 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     #template path : ./templates/templatesXS/DTreeXS_{obsName}/8TeV/
     #template name : XSBackground_{bkgTag}_{finalStateString}_{obsName}_recobin{binNum}.root
 
-    template_qqzzName = "./templates/templatesXS/DTreeXS_"+obsName+"/13TeV/XSBackground_qqZZ_"+channel+"_"+obsName+"_"+obsBin_low+"_"+obsBin_high+".root"
-    template_ggzzName = "./templates/templatesXS/DTreeXS_"+obsName+"/13TeV/XSBackground_ggZZ_"+channel+"_"+obsName+"_"+obsBin_low+"_"+obsBin_high+".root"
+    logger.debug("SuffixOfRootFile: "+SuffixOfRootFile)
+    template_qqzzName = "./templates/templatesXS/DTreeXS_"+obsNameDictKey+"/13TeV/XSBackground_qqZZ_"+channel+"_"+SuffixOfRootFile+".root"
+    template_ggzzName = "./templates/templatesXS/DTreeXS_"+obsNameDictKey+"/13TeV/XSBackground_ggZZ_"+channel+"_"+SuffixOfRootFile+".root"
     if (not obsName=="mass4l"):
-        template_zjetsName = "./templates/templatesXS/DTreeXS_"+obsName+"/13TeV/XSBackground_ZJetsCR_AllChans_"+obsName+"_"+obsBin_low+"_"+obsBin_high+".root"
+        template_zjetsName = "./templates/templatesXS/DTreeXS_"+obsNameDictKey+"/13TeV/XSBackground_ZJetsCR_AllChans_"+SuffixOfRootFile+".root"
     else:
-        template_zjetsName = "./templates/templatesXS/DTreeXS_"+obsName+"/13TeV/XSBackground_ZJetsCR_"+channel+"_"+obsName+"_"+obsBin_low+"_"+obsBin_high+".root"
-
+        template_zjetsName = "./templates/templatesXS/DTreeXS_"+obsNameDictKey+"/13TeV/XSBackground_ZJetsCR_"+channel+"_"+SuffixOfRootFile+".root"
     qqzzTempFile = TFile(template_qqzzName,"READ")
-    qqzzTemplate = qqzzTempFile.Get("m4l_"+obsName+"_"+obsBin_low+"_"+obsBin_high)
+    qqzzTemplate = qqzzTempFile.Get("m4l_"+SuffixOfRootFile)
     print('[INFO] qqZZ bins : {}, {}, {}'.format(qqzzTemplate.GetNbinsX(),qqzzTemplate.GetBinLowEdge(1),qqzzTemplate.GetBinLowEdge(qqzzTemplate.GetNbinsX()+1)))
 
     ggzzTempFile = TFile(template_ggzzName,"READ")
-    ggzzTemplate = ggzzTempFile.Get("m4l_"+obsName+"_"+obsBin_low+"_"+obsBin_high)
+    ggzzTemplate = ggzzTempFile.Get("m4l_"+SuffixOfRootFile)
     print('[INFO] ggZZ bins : {}, {}, {}'.format(ggzzTemplate.GetNbinsX(),ggzzTemplate.GetBinLowEdge(1),ggzzTemplate.GetBinLowEdge(ggzzTemplate.GetNbinsX()+1)))
 
     zjetsTempFile = TFile(template_zjetsName,"READ")
-    zjetsTemplate = zjetsTempFile.Get("m4l_"+obsName+"_"+obsBin_low+"_"+obsBin_high)
+    zjetsTemplate = zjetsTempFile.Get("m4l_"+SuffixOfRootFile)
     print('[INFO] zjets bins: {}, {}, {}'.format(zjetsTemplate.GetNbinsX(),zjetsTemplate.GetBinLowEdge(1),zjetsTemplate.GetBinLowEdge(zjetsTemplate.GetNbinsX()+1)))
 
     binscale = 3 # FIXME: Why number 3 hardcoded?
@@ -494,14 +574,17 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     if (channel=='4mu'):
         if (obsName.startswith("mass4l")): data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4mu),"(mass4mu>105.0 && mass4mu<140.0)")
         elif (obsName.startswith("abs")):  data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4mu,observable),"(mass4mu>105.0 && mass4mu<140.0 && "+obsName+">="+obsBin_low+" && "+obsName+"<"+obsBin_high+")")
-        else: data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4mu,observable),"(mass4mu>105.0 && mass4mu<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+")")
+        elif is2DObs: data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4mu,observable,observable2),"(mass4mu>105.0 && mass4mu<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+" && abs("+obsNameOrig[1]+")>="+obsBin_low2+" && abs("+obsName+")<"+obsBin_high2+")")
+        else:                  data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4mu,observable),                    "(mass4mu>105.0 && mass4mu<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+")")
     if (channel=='4e'):
         if (obsName.startswith("mass4l")): data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4e),"(mass4e>105.0 && mass4e<140.0)")
         elif (obsName.startswith("abs")):  data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4e,observable),"(mass4e>105.0 && mass4e<140.0 && "+obsName+">="+obsBin_low+" && "+obsName+"<"+obsBin_high+")")
+        elif is2DObs: data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4e,observable,observable2),"(mass4e>105.0 && mass4e<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+" && abs("+obsNameOrig[1]+")>="+obsBin_low2+" && abs("+obsName+")<"+obsBin_high2+")")
         else: data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass4e,observable),"(mass4e>105.0 && mass4e<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+")")
     if (channel=='2e2mu'):
         if (obsName.startswith("mass4l")): data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass2e2mu),"(mass2e2mu>105.0 && mass2e2mu<140.0)")
         elif (obsName.startswith("abs")):  data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass2e2mu,observable),"(mass2e2mu>105.0 && mass2e2mu<140.0 && "+obsName+">="+obsBin_low+" && "+obsName+"<"+obsBin_high+")")
+        elif is2DObs: data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass2e2mu,observable,observable2),"(mass2e2mu>105.0 && mass2e2mu<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+" && abs("+obsNameOrig[1]+")>="+obsBin_low2+" && abs("+obsName+")<"+obsBin_high2+")")
         else: data_obs = RooDataSet("data_obs","data_obs",data_obs_tree,RooArgSet(m,mass2e2mu,observable),"(mass2e2mu>105.0 && mass2e2mu<140.0 && abs("+obsName+")>="+obsBin_low+" && abs("+obsName+")<"+obsBin_high+")")
     #for event in range(data_obs.numEntries()):
     #    row = data_obs.get(event)
@@ -545,7 +628,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
         getattr(wout,'import')(CMS_zz4l_n2_1_8_centralValue,RooFit.RecycleConflictNodes())
         getattr(wout,'import')(CMS_zz4l_mean_m_err_1_8,RooFit.RecycleConflictNodes())
 
-    for genbin in range(nBins-1):
+    for genbin in range(nBins):
         # For Silence issue we should shift to ROOT 6.18
         # Reference: https://root-forum.cern.ch/t/rooworkspace-import-roofit-silence-does-not-work-when-importing-datasets/32591/2
         getattr(wout,'import')(trueH_shape[genbin],RooFit.RecycleConflictNodes()) # RooFit.Silence()
@@ -580,16 +663,17 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
 
     if (addfakeH):
         if (usecfactor):
-            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsName+"_"+physicalModel+".Databin"+str(obsBin)+".Cfactor.root","RECREATE")
+            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsNameDictKey+"_"+physicalModel+".Databin"+str(obsBin)+".Cfactor.root","RECREATE")
         else:
-            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsName+"_"+physicalModel+".Databin"+str(obsBin)+".root","RECREATE")
+            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsNameDictKey+"_"+physicalModel+".Databin"+str(obsBin)+".root","RECREATE")
     else:
         if (usecfactor):
-            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsName+"_"+physicalModel+".Databin"+str(obsBin)+".Cfactor.NoFakeH.root","RECREATE")
+            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsNameDictKey+"_"+physicalModel+".Databin"+str(obsBin)+".Cfactor.NoFakeH.root","RECREATE")
         else:
-            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsName+"_"+physicalModel+".Databin"+str(obsBin)+".NoFakeH.root","RECREATE")
+            fout = TFile(combineOutputs+"/hzz4l_"+channel+"S_13TeV_xs_"+modelName+"_"+obsNameDictKey+"_"+physicalModel+".Databin"+str(obsBin)+".NoFakeH.root","RECREATE")
 
-    print ("write ws to fout")
+    logger.info("write workspace to output root file")
+    logger.debug("Total entries in data_obs: "+str(data_obs.numEntries()))
     fout.WriteTObject(wout)
     fout.Close()
 

--- a/python/createXSworkspace.py
+++ b/python/createXSworkspace.py
@@ -20,6 +20,9 @@ from ROOT import *
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
 from Utils import  logger
+import logging
+
+logger.setLevel(logging.DEBUG)
 
 sys.path.append('./'+datacardInputs)
 

--- a/python/createXSworkspace.py
+++ b/python/createXSworkspace.py
@@ -183,7 +183,6 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
 
 
     # Wrong signal combination events
-
     if (channel=='4mu'):
         #p1_1_8 = RooRealVar("CMS_fakeH_p1_1_8","p1_1_8", 150.0, 135.0, 185.)
         #p2_1_8 = RooRealVar("CMS_fakeH_p2_1_8","p2_1_8", 20.0, 10.0, 40.0)
@@ -227,6 +226,7 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
     binfrac_wrongfrac_ttH=binfrac_wrongfrac["ttH_powheg_JHUgen_125_"+channel+"_"+obsName+"_genbin"+str(obsBin)+"_"+recobin]
 
     if (channel=='4e'):
+        # FIXME: Check these values
         n_fakeH = (0.24*inc_wrongfrac_WH*binfrac_wrongfrac_WH+0.20*inc_wrongfrac_ZH*binfrac_wrongfrac_ZH+0.10*inc_wrongfrac_ttH*binfrac_wrongfrac_ttH)
     if (channel=='4mu'):
         n_fakeH = (0.45*inc_wrongfrac_WH*binfrac_wrongfrac_WH+0.38*inc_wrongfrac_ZH*binfrac_wrongfrac_ZH+0.20*inc_wrongfrac_ttH*binfrac_wrongfrac_ttH)

--- a/python/createXSworkspace.py
+++ b/python/createXSworkspace.py
@@ -392,12 +392,12 @@ def createXSworkspace(obsName, channel, nBins, obsBin, observableBins, usecfacto
             fidxs = {}
             for fState in ['4e','4mu', '2e2mu']:
                 fidxs[fState] = 0
-                fidxs[fState] += higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-                #fidxs[fState] += acc['ggH_HRes_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-                fidxs[fState] += higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-                fidxs[fState] += higgs_xs['WH_125.0']*higgs4l_br['125.0_'+fState]*acc['WH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-                fidxs[fState] += higgs_xs['ZH_125.0']*higgs4l_br['125.0_'+fState]*acc['ZH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
-                fidxs[fState] += higgs_xs['ttH_125.0']*higgs4l_br['125.0_'+fState]*acc['ttH_powheg_JHUgen_125_'+fState+'_'+obsName+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+                fidxs[fState] += higgs_xs['ggH_125.0']*higgs4l_br['125.0_'+fState]*acc['ggH_powheg_JHUgen_125_'+fState+'_'+obsNameDictKey+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+                #fidxs[fState] += acc['ggH_HRes_125_'+fState+'_'+obsNameDictKey+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+                fidxs[fState] += higgs_xs['VBF_125.0']*higgs4l_br['125.0_'+fState]*acc['VBF_powheg_JHUgen_125_'+fState+'_'+obsNameDictKey+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+                fidxs[fState] += higgs_xs['WH_125.0']*higgs4l_br['125.0_'+fState]*acc['WH_powheg_JHUgen_125_'+fState+'_'+obsNameDictKey+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+                fidxs[fState] += higgs_xs['ZH_125.0']*higgs4l_br['125.0_'+fState]*acc['ZH_powheg_JHUgen_125_'+fState+'_'+obsNameDictKey+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
+                fidxs[fState] += higgs_xs['ttH_125.0']*higgs4l_br['125.0_'+fState]*acc['ttH_powheg_JHUgen_125_'+fState+'_'+obsNameDictKey+'_genbin'+str(genbin)+'_recobin'+str(genbin)]
             fidxs['4l'] = fidxs['4e'] + fidxs['4mu'] + fidxs['2e2mu']
 
             fracSM4eBin[str(genbin)] = RooRealVar('fracSM4eBin'+str(genbin), 'fracSM4eBin'+str(genbin), fidxs['4e']/fidxs['4l'])

--- a/python/interpolate_differential_pred.py
+++ b/python/interpolate_differential_pred.py
@@ -5,7 +5,6 @@ import os
 from scipy import interpolate
 
 from Utils import *
-# from python import *
 
 def parseOptions():
 
@@ -123,11 +122,12 @@ def interpolate_pred(x, nbins, obsName, DEBUG):
             qcdunc_ggH_powheg[str(key_NNLOPS_MX)]['uncerUp']=qcdunc_ggH_powheg[key_NNLOPS_M125]['uncerUp']*qcdunc_ggH_powheg[str(key_powheg_MX)]['uncerUp']/qcdunc_ggH_powheg[str(key_powheg_M125)]['uncerUp']  #acceptance[key_powheg_MX]
             qcdunc_ggH_powheg[str(key_NNLOPS_MX)]['uncerDn']=qcdunc_ggH_powheg[key_NNLOPS_M125]['uncerDn']*qcdunc_ggH_powheg[str(key_powheg_MX)]['uncerDn']/qcdunc_ggH_powheg[str(key_powheg_M125)]['uncerDn']  #acceptance[key_powheg_MX]
 
-
+    # FIXME: Hardcoded path
+    DirForUncFiles = "python"
     OutputDictFileName = 'accUnc_'+obsName+'.py'
-    os.system('cp ' + OutputDictFileName + " " + OutputDictFileName.replace('.py','_beforeInterpolation.py'))
+    os.system('cp ' + DirForUncFiles + '/' + OutputDictFileName + " " +DirForUncFiles+'/'+ OutputDictFileName.replace('.py','_beforeInterpolation.py'))
 
-    with open(OutputDictFileName, 'w') as f:
+    with open(DirForUncFiles + '/' + OutputDictFileName, 'w') as f:
         print("going write interpolated values in file:   " + OutputDictFileName)
         f.write('acc = '+str(acc_ggH_powheg)+' \n')
         f.write('qcdUncert = '+str(qcdunc_ggH_powheg)+' \n')

--- a/python/plotAsimov_inclusive.py
+++ b/python/plotAsimov_inclusive.py
@@ -8,7 +8,8 @@ from math import *
 # INFO: Following items are imported from either python directory or Inputs
 from sample_shortnames import *
 from Input_Info import *
-
+from read_bins import read_bins
+from Utils import logger
 
 grootargs = []
 def callback_rootargs(option, opt, value, parser):
@@ -51,17 +52,28 @@ from ROOT import *
 from tdrStyle import *
 setTDRStyle()
 
-if (not os.path.exists("plots")):
-    os.system("mkdir plots")
 
 modelName = opt.UNFOLD
 physicalModel = 'v2'
 asimovDataModel = opt.ASIMOV
 asimovPhysicalModel = 'v2'
 obsName = opt.OBSNAME
-observableBins = opt.OBSBINS.split('|')
-observableBins.pop()
-observableBins.pop(0)
+ListObsName = (''.join(obsName.split())).split('vs')
+
+observableBins = read_bins(opt.OBSBINS)
+logger.info("Parsed bins: {}".format(observableBins))
+logger.info("Bin size = "+str(len(observableBins)))
+
+nBins = len(observableBins) -1
+if len(ListObsName) == 2:    # INFO: for 2D this list size == 2
+    nBins = len(observableBins)
+logger.debug("nBins: = "+str(nBins))
+
+#asimovModelName = 'ggH_powheg15_JHUgen_125'
+#asimovPhysicalModel = 'v2'
+#modelName = 'ggH_powheg15_JHUgen_125'
+#physicalModel = 'v2'
+#recobin = 0
 
 def plotAsimov(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, obsName, fstate, recobin):
 
@@ -75,8 +87,8 @@ def plotAsimov(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, o
 
     RooMsgService.instance().setGlobalKillBelow(RooFit.WARNING)
 
-    print('[INFO] Filename: {}'.format(asimovDataModel+'_all_'+obsName+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ'))
-    f_asimov = TFile(combineOutputs+'/'+asimovDataModel+'_all_'+obsName+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ')
+    print('[INFO] Filename: {}'.format(asimovDataModel+'_all_'+obsName.replace(' ','_')+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ'))
+    f_asimov = TFile(combineOutputs+'/'+asimovDataModel+'_all_'+obsName.replace(' ','_')+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ')
     if (not opt.UNBLIND):
         data = f_asimov.Get("toys/toy_asimov");
     #data.Print("v");
@@ -130,7 +142,7 @@ def plotAsimov(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, o
         n_qqzz_asimov["4l"] += qqzz_asimov[fState].getVal()
         n_zz_asimov["4l"] += n_ggzz_asimov[fState]+n_qqzz_asimov[fState]
 
-    f_modelfit = TFile(combineOutputs+'/'+modelName+'_all_13TeV_xs_'+obsName+'_bin_'+physicalModel+'_result.root','READ')
+    f_modelfit = TFile(combineOutputs+'/'+modelName+'_all_13TeV_xs_'+obsName.replace(' ','_')+'_bin_'+physicalModel+'_result.root','READ')
     w_modelfit = f_modelfit.Get("w")
     sim = w_modelfit.pdf("model_s")
     #sim.Print("v")
@@ -334,30 +346,19 @@ def plotAsimov(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, o
     latex2.SetTextSize(0.45*c.GetTopMargin())
     #latex2.DrawLatex(0.20,0.85,"Unfolding model: "+modelName.replace("_"," ")+" GeV")
 
+    # Create output directory if it does not exits
+    OutputPath = AsimovPlots.format(obsName = obsName.replace(' ','_'))
+    if not os.path.isdir(OutputPath):
+        os.makedirs(OutputPath)
 
     if (not opt.UNBLIND):
-        c.SaveAs("plots/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".pdf")
-        c.SaveAs("plots/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".png")
+        c.SaveAs(OutputPath+"/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".pdf")
+        c.SaveAs(OutputPath+"/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".png")
     else:
-        c.SaveAs("plots/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".pdf")
-        c.SaveAs("plots/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".png")
+        c.SaveAs(OutputPath+"/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".pdf")
+        c.SaveAs(OutputPath+"/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".png")
 
-
-modelName = opt.UNFOLD
-physicalModel = 'v2'
-asimovDataModel = opt.ASIMOV
-asimovPhysicalModel = 'v2'
-obsName = opt.OBSNAME
-observableBins = opt.OBSBINS.split('|')
-observableBins.pop()
-observableBins.pop(0)
-
-#asimovModelName = 'ggH_powheg15_JHUgen_125'
-#asimovPhysicalModel = 'v2'
-#modelName = 'ggH_powheg15_JHUgen_125'
-#physicalModel = 'v2'
-#recobin = 0
 
 for fState in ["4e","4mu","2e2mu","4l"]:
-    for recobin in range(len(observableBins)-1):
+    for recobin in range(nBins):
         plotAsimov(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, 'mass4l', fState, recobin)

--- a/python/plotAsimov_simultaneous.py
+++ b/python/plotAsimov_simultaneous.py
@@ -3,11 +3,14 @@ import os
 import sys
 from decimal import *
 from math import *
+import yaml
 
 
 # INFO: Following items are imported from either python directory or Inputs
 from Input_Info import *
 from sample_shortnames import *
+from read_bins import read_bins
+from Utils import logger, border_msg
 
 grootargs = []
 def callback_rootargs(option, opt, value, parser):
@@ -24,6 +27,7 @@ def parseOptions():
 
     # input options
     parser.add_option('-d', '--dir',    dest='SOURCEDIR',  type='string',default='./', help='run from the SOURCEDIR as working area, skip if SOURCEDIR is an empty string')
+    parser.add_option('',   '--inYAMLFile', dest='inYAMLFile', type='string', default="Inputs/observables_list.yml", help='Input YAML file having observable names and bin information')
     parser.add_option('',   '--asimovModel',dest='ASIMOV',type='string',default='ggH_powheg15_JHUgen_125', help='Name of the asimov data mode')
     parser.add_option('',   '--asimovMass',dest='ASIMOVMASS',type='string',default='125.0', help='Asimov Mass')
     parser.add_option('',   '--unfoldModel',dest='UNFOLD',type='string',default='ggH_powheg15_JHUgen_125', help='Name of the unfolding model')
@@ -34,6 +38,7 @@ def parseOptions():
     parser.add_option("-l",action="callback",callback=callback_rootargs)
     parser.add_option("-q",action="callback",callback=callback_rootargs)
     parser.add_option("-b",action="callback",callback=callback_rootargs)
+    parser.add_option('', '--obs', dest='OneDOr2DObs', default=1, type=int, help="1 for 1D obs, 2 for 2D observable")
 
     # store options and arguments as global variables
     global opt, args
@@ -49,22 +54,28 @@ from ROOT import *
 from tdrStyle import *
 setTDRStyle()
 
-if (not os.path.exists("plots")):
-    os.system("mkdir plots")
-
 modelName = opt.UNFOLD
 physicalModel = 'v3'
 asimovDataModel = opt.ASIMOV
 asimovPhysicalModel = 'v2'
 obsName = opt.OBSNAME
-observableBins = opt.OBSBINS.split('|')
-observableBins.pop()
-observableBins.pop(0)
+ListObsName = (''.join(obsName.split())).split('vs')
+
+observableBins = read_bins(opt.OBSBINS)
+logger.info("Parsed bins: {}".format(observableBins))
+logger.info("Bin size = "+str(len(observableBins)))
+
+nBins = len(observableBins) -1
+if len(ListObsName) == 2:    # INFO: for 2D this list size == 2
+    nBins = len(observableBins)
+logger.debug("nBins: = "+str(nBins))
+
+ObsToStudy = "1D_Observables" if opt.OneDOr2DObs == 1 else "2D_Observables"
 
 def plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, obsName, fstate, observableBins, recobin):
 
-
-    nBins = len(observableBins)-1
+    global nBins, ObsToStudy
+    logger.debug("nBins: = "+str(nBins))
     channel = {"4mu":"1", "4e":"2", "2e2mu":"3", "4l":"2"} # 4l is dummy, won't be used
 
     # Load some libraries
@@ -75,9 +86,9 @@ def plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalMode
 
     RooMsgService.instance().setGlobalKillBelow(RooFit.WARNING)
 
-    print (asimovDataModel+'_all_'+obsName+'_13TeV_Asimov_'+asimovPhysicalModel+'.root')
+    print (asimovDataModel+'_all_'+obsName.replace(' ','_')+'_13TeV_Asimov_'+asimovPhysicalModel+'.root')
     # FIXME: Improve the directory naming/pointer of hardcoded directory
-    f_asimov = TFile(combineOutputs+'/'+asimovDataModel+'_all_'+obsName+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ')
+    f_asimov = TFile(combineOutputs+'/'+asimovDataModel+'_all_'+obsName.replace(' ','_')+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ')
 
     if (not opt.UNBLIND):
         data = f_asimov.Get("toys/toy_asimov");
@@ -144,9 +155,9 @@ def plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalMode
         n_zz_asimov["4l"] += n_ggzz_asimov[fState]+n_qqzz_asimov[fState]
 
 
-    print (modelName+'_all_13TeV_xs_'+obsName+'_bin_'+physicalModel+'_result.root')
+    print (modelName+'_all_13TeV_xs_'+obsName.replace(' ','_')+'_bin_'+physicalModel+'_result.root')
     # FIXME: Improve the directory naming/pointer of hardcoded directory
-    f_modelfit = TFile(combineOutputs+"/"+modelName+'_all_13TeV_xs_'+obsName+'_bin_'+physicalModel+'_result.root','READ')
+    f_modelfit = TFile(combineOutputs+"/"+modelName+'_all_13TeV_xs_'+obsName.replace(' ','_')+'_bin_'+physicalModel+'_result.root','READ')
     w_modelfit = f_modelfit.Get("w")
     sim = w_modelfit.pdf("model_s")
     #sim.Print("v")
@@ -347,64 +358,16 @@ def plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalMode
 
     mass.Draw("same")
 
-    # FIXME: Also, this part we can define at one central place, probably in yaml file
-    if (obsName=="pT4l"):
-        label="p_{T}^{H}"
-        unit="GeV"
-    elif (obsName=="massZ2"):
-        label = "m(Z_{2})"
-        unit = "GeV"
-    elif (obsName=="massZ1"):
-        label = "m(Z_{1})"
-        unit = "GeV"
-    elif (obsName=="nJets" or obsName=="njets_reco_pt30_eta4p7"):
-        label = "N(jets) |#eta|<4.7"
-        unit = ""
-    elif (obsName=="njets_pt30_eta2p5"):
-        label = "N(jets) |#eta|<2.5"
-        unit = ""
-    elif (obsName=='pt_leadingjet_pt30_eta4p7'):
-        label = "p_{T}(jet)"
-        unit = "GeV"
-    elif (obsName=='pt_leadingjet_pt30_eta2p5'):
-        label = "p_{T}(jet) |#eta|<2.5"
-        unit = "GeV"
-    elif (obsName=='absdeltarapidity_hleadingjet_pt30_eta4p7'):
-        label = "|y(H)-y(jet)|"
-        unit = ""
-    elif (obsName=='absdeltarapidity_hleadingjet_pt30_eta2p5'):
-        label = "|y(H)-y(jet)| |#eta|<2.5"
-        unit = ""
-    elif (obsName=='absrapidity_leadingjet_pt30_eta4p7'):
-        label = "|y(jet)|"
-        unit = ""
-    elif (obsName=='absrapidity_leadingjet_pt30_eta2p5'):
-        label = "|y(jet)| |#eta|<2.5"
-        unit = ""
-    elif (obsName=="rapidity4l"):
-        label = "|y^{H}|"
-        unit = ""
-    elif (obsName=="cosThetaStar"):
-        label = "cos#theta*"
-        unit = ""
-    elif (obsName=="cosTheta1"):
-        label = "cos#theta_{1}"
-        unit = ""
-    elif (obsName=="cosTheta2"):
-        label = "cos#theta_{2}"
-        unit = ""
-    elif (obsName=="Phi"):
-        label = "#Phi"
-        unit = ""
-    elif (obsName=="Phi1"):
-        label = "#Phi_{1}"
-        unit = ""
-    elif (obsName=="mass4l"):
-        label = "inclusive"
-        unit = ""
-    else:
-        label = obsName
-        unit = ""
+    # Get label name & Unit from YAML file.
+    with open(opt.inYAMLFile, 'r') as ymlfile:
+        cfg = yaml.load(ymlfile)
+        if ( ("Observables" not in cfg) or (ObsToStudy not in cfg['Observables']) ) :
+            print('''No section named 'observable' or sub-section name '1D-Observable' found in file {}.
+                    Please check your YAML file format!!!'''.format(InputYAMLFile))
+
+        label = cfg['Observables'][ObsToStudy][obsName]['label']
+        unit = cfg['Observables'][ObsToStudy][obsName]['unit']
+        border_msg("Label name: {}, Unit: {}".format(label, unit))
 
     latex2 = TLatex()
     latex2.SetNDC()
@@ -429,15 +392,20 @@ def plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalMode
     #latex2.DrawLatex(0.20,0.85, observableBins[recobin]+" "+unit+" < "+label+" < "+observableBins[recobin+1]+" "+unit+"    Unfolding model: "+modelName.replace("_"," ")+" GeV")
     latex2.DrawLatex(0.65,0.85, observableBins[recobin]+" "+unit+" < "+label+" < "+observableBins[recobin+1]+" "+unit)
 
+    # Create output directory if it does not exits
+    OutputPath = AsimovPlots.format(obsName = obsName.replace(' ','_'))
+    if not os.path.isdir(OutputPath):
+        os.makedirs(OutputPath)
+
     if (not opt.UNBLIND):
-        c.SaveAs("plots/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".pdf")
-        c.SaveAs("plots/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".png")
+        c.SaveAs(OutputPath+"/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".pdf")
+        c.SaveAs(OutputPath+"/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".png")
     else:
-        c.SaveAs("plots/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".pdf")
-        c.SaveAs("plots/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName+'_'+fstate+"_recobin"+str(recobin)+".png")
+        c.SaveAs(OutputPath+"/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".pdf")
+        c.SaveAs(OutputPath+"/data_unfoldwith_"+modelName+"_"+physicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+"_recobin"+str(recobin)+".png")
 
 
 fStates = ["4e","4mu","2e2mu","4l"]
 for fState in fStates:
-    for recobin in range(len(observableBins)-1):
+    for recobin in range(nBins):
         plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalModel, obsName, fState, observableBins, recobin)

--- a/python/plotAsimov_simultaneous.py
+++ b/python/plotAsimov_simultaneous.py
@@ -390,8 +390,15 @@ def plotAsimov_sim(asimovDataModel, asimovPhysicalModel, modelName, physicalMode
     latex2.SetTextFont(42)
     latex2.SetTextSize(0.45*c.GetTopMargin())
     #latex2.DrawLatex(0.20,0.85, observableBins[recobin]+" "+unit+" < "+label+" < "+observableBins[recobin+1]+" "+unit+"    Unfolding model: "+modelName.replace("_"," ")+" GeV")
-    latex2.DrawLatex(0.65,0.85, observableBins[recobin]+" "+unit+" < "+label+" < "+observableBins[recobin+1]+" "+unit)
-
+    if (ObsToStudy == "1D_Observables"):
+        latex2.DrawLatex(0.65,0.85, observableBins[recobin]+" "+unit+" < "+label+" < "+observableBins[recobin+1]+" "+unit)
+    else:
+        # print( observableBins[recobin])
+        # print(observableBins[recobin])
+        latex2.DrawLatex(0.65,0.85, observableBins[recobin][0][0]+" "+unit+" < "+label[0]+" < "+observableBins[recobin][0][1]+" "+unit)
+        latex2.DrawLatex(0.65,0.75, observableBins[recobin][1][0]+" "+unit+" < "+label[1]+" < "+observableBins[recobin][1][1]+" "+unit)
+        # exit()
+        # latex2.DrawLatex(0.65,0.85, observableBins[recobin]+" "+unit+" < "+label+" < "+observableBins[recobin+1]+" "+unit)
     # Create output directory if it does not exits
     OutputPath = AsimovPlots.format(obsName = obsName.replace(' ','_'))
     if not os.path.isdir(OutputPath):

--- a/python/plotDifferentialBins.py
+++ b/python/plotDifferentialBins.py
@@ -66,7 +66,11 @@ if float(observableBins[len(observableBins)-1])>200.0:
 def plotDifferentialBins(asimovDataModel, asimovPhysicalModel, obsName, fstate, observableBins):
 
 
-    nBins = len(observableBins)-1
+    if ('vs' in obsName):
+        nBins = len(observableBins)
+    else:
+        nBins = len(observableBins)-1
+
     # FIXME: we could relate channel and fstate???
     # FIXME: Channels and fstates are given at many places.
     # FIXME: Is it possible to define them at one place and grab it where its necessary?
@@ -81,7 +85,7 @@ def plotDifferentialBins(asimovDataModel, asimovPhysicalModel, obsName, fstate, 
     RooMsgService.instance().setGlobalKillBelow(RooFit.WARNING)
 
     # FIXME: Improve the directory naming/pointer of hardcoded directory
-    f_asimov = TFile(combineOutputs+"/"+asimovDataModel+'_all_'+obsName+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ')
+    f_asimov = TFile(combineOutputs+"/"+asimovDataModel+'_all_'+obsName.replace(' ','_')+'_13TeV_Asimov_'+asimovPhysicalModel+'.root','READ')
     if (not opt.UNBLIND):
         data = f_asimov.Get("toys/toy_asimov");
     #data.Print("v");

--- a/python/plotDifferentialBins.py
+++ b/python/plotDifferentialBins.py
@@ -9,7 +9,8 @@ import yaml
 # INFO: Following items are imported from either python directory or Inputs
 from sample_shortnames import *
 from Input_Info import *
-from Utils import *
+from read_bins import read_bins
+from Utils import logger, border_msg
 
 grootargs = []
 def callback_rootargs(option, opt, value, parser):
@@ -50,26 +51,30 @@ from ROOT import *
 from tdrStyle import *
 setTDRStyle()
 
-if (not os.path.exists("plots")):
-    os.system("mkdir plots")
 
 asimovDataModel = opt.ASIMOV
 asimovPhysicalModel = 'v2'
 obsName = opt.OBSNAME
-observableBins = opt.OBSBINS.split('|')
-observableBins.pop()
-observableBins.pop(0)
-print("{}".format(float(observableBins[len(observableBins)-1])))
-if float(observableBins[len(observableBins)-1])>200.0:
-    observableBins[len(observableBins)-1]='200.0'
+ListObsName = (''.join(obsName.split())).split('vs')
+
+observableBins = read_bins(opt.OBSBINS)
+logger.info("Parsed bins: {}".format(observableBins))
+logger.info("Bin size = "+str(len(observableBins)))
+
+nBins = len(observableBins) -1
+if len(ListObsName) == 2:    # INFO: for 2D this list size == 2
+    nBins = len(observableBins)
+logger.debug("nBins: = "+str(nBins))
+
+
+if len(ListObsName) == 1:    # INFO: for 2D this list size == 1
+    print("{}".format(float(observableBins[nBins])))
+    if float(observableBins[nBins])>200.0:
+        observableBins[nBins]='200.0'
 
 def plotDifferentialBins(asimovDataModel, asimovPhysicalModel, obsName, fstate, observableBins):
 
-
-    if ('vs' in obsName):
-        nBins = len(observableBins)
-    else:
-        nBins = len(observableBins)-1
+    global nBins
 
     # FIXME: we could relate channel and fstate???
     # FIXME: Channels and fstates are given at many places.
@@ -230,7 +235,7 @@ def plotDifferentialBins(asimovDataModel, asimovPhysicalModel, obsName, fstate, 
     c = TCanvas("c","c",1000,800)
     c.cd()
 
-    # Get label name from YAML file.
+    # Get label name & Unit from YAML file.
     with open(opt.inYAMLFile, 'r') as ymlfile:
         cfg = yaml.load(ymlfile)
         if ( ("Observables" not in cfg) or ("1D_Observables" not in cfg['Observables']) ) :
@@ -240,60 +245,6 @@ def plotDifferentialBins(asimovDataModel, asimovPhysicalModel, obsName, fstate, 
         label = cfg['Observables']['1D_Observables'][obsName]['label']
         unit = cfg['Observables']['1D_Observables'][obsName]['unit']
         border_msg("Label name: {}, Unit: {}".format(label, unit))
-
-
-    # # FIXME: Also, this part we can define at one central place, probably in yaml file
-    # if (obsName=="pT4l"):
-    #     label="p_{T}^{H}"
-    #     unit="GeV"
-    # elif (obsName=="massZ2"):
-    #     label = "m(Z_{2})"
-    #     unit = "GeV"
-    # elif (obsName=="massZ1"):
-    #     label = "m(Z_{1})"
-    #     unit = "GeV"
-    # elif (obsName=="nJets" or obsName=="njets_pt30_eta4p7"):
-    #     label = "N(jets) |#eta|<4.7"
-    #     unit = ""
-    # elif (obsName=="njets_pt30_eta2p5"):
-    #     label = "N(jets) |#eta|<2.5"
-    #     unit = ""
-    # elif (obsName=="pt_leadingjet_pt30_eta4p7"):
-    #     label = "p_{T}(jet)"
-    #     unit = "GeV"
-    # elif (obsName=="pt_leadingjet_pt30_eta2p5"):
-    #     label = "p_{T}(jet) |#eta|<2.5"
-    #     unit = "GeV"
-    # elif (obsName=="absrapidity_leadingjet_pt30_eta4p7"):
-    #     label = "|y(jet)|"
-    #     unit = ""
-    # elif (obsName=="absrapidity_leadingjet_pt30_eta2p5"):
-    #     label = "|y(jet)| |#eta|<2.5"
-    #     unit = ""
-    # elif (obsName=="absdeltarapidity_hleadingjet_pt30_eta4p7"):
-    #     label = "|y(H)-y(jet)|"
-    #     unit = ""
-    # elif (obsName=="absdeltarapidity_hleadingjet_pt30_eta2p5"):
-    #     label = "|y(H)-y(jet)| |#eta|<2.5"
-    #     unit = ""
-    # elif (obsName=="rapidity4l"):
-    #     label = "|y^{H}|"
-    #     unit = ""
-    # elif (obsName=="cosThetaStar"):
-    #     label = "cos#theta*"
-    #     unit = ""
-    # elif (obsName=="cosTheta1"):
-    #     label = "cos#theta_{1}"
-    #     unit = ""
-    # elif (obsName=="cosTheta2"):
-    #     label = "cos#theta_{2}"
-    #     unit = ""
-    # elif (obsName=="Phi"):
-    #     label = "#Phi"
-    #     unit = ""
-    # elif (obsName=="Phi1"):
-    #     label = "#Phi_{1}"
-    #     unit = ""
 
 
     if (obsName.startswith("njets")):
@@ -359,12 +310,16 @@ def plotDifferentialBins(asimovDataModel, asimovPhysicalModel, obsName, fstate, 
     legend.SetLineColor(0);
     legend.Draw()
 
+    # Create output directory if it does not exits
+    OutputPath = DifferentialBins.format(obsName = obsName.replace(' ','_'))
+    if not os.path.isdir(OutputPath):
+        os.makedirs(OutputPath)
     if (not opt.UNBLIND):
-        c.SaveAs("plots/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_"+obsName+'_'+fstate+".pdf")
-        c.SaveAs("plots/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_"+obsName+'_'+fstate+".png")
+        c.SaveAs(OutputPath+"/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+".pdf")
+        c.SaveAs(OutputPath+"/asimovdata_"+asimovDataModel+"_"+asimovPhysicalModel+"_"+obsName.replace(' ','_')+'_'+fstate+".png")
     else:
-        c.SaveAs("plots/data_"+obsName+'_'+fstate+".pdf")
-        c.SaveAs("plots/data_"+obsName+'_'+fstate+".png")
+        c.SaveAs(OutputPath+"/data_"+obsName.replace(' ','_')+'_'+fstate+".pdf")
+        c.SaveAs(OutputPath+"/data_"+obsName.replace(' ','_')+'_'+fstate+".png")
 
 
 fStates = ["4e","4mu","2e2mu","4l"]

--- a/runHZZFiducialXS.py
+++ b/runHZZFiducialXS.py
@@ -219,40 +219,38 @@ def extractBackgroundTemplatesAndFractions(obsName, observableBins):
                 logger.debug('tmp_fracs: {}'.format(tmp_fracs))
                 logger.debug('Length of observables bins: {}'.format(len(observableBins)))
 
-                for obsBin in range(0,1): # FIXME & DISCUSS: Here I (Ram) hardcoded the value 1. Will test with with other 2D obs then generalize. Currently, checking with massZ1 vs massZ2
-                    logger.debug('obsBin: '+str(obsBin))
-                    tag_ = sample_tag+'_'+bkg_samples_fStates[sample_tag]+'_'+obsName.replace(' ','_')+'_recobin'+str(nBins_)
-                    logger.debug('tag_ : {}'.format(tag_))
+                tag_ = sample_tag+'_'+bkg_samples_fStates[sample_tag]+'_'+obsName.replace(' ','_')+'_recobin'+str(nBins_)
+                logger.debug('tag_ : {}'.format(tag_))
 
-                    fractionBkg[tag_] = 0
-                    lambdajesupBkg[tag_] = 0
-                    lambdajesdnBkg[tag_] = 0
+                fractionBkg[tag_] = 0
+                lambdajesupBkg[tag_] = 0
+                lambdajesdnBkg[tag_] = 0
 
-                    logger.debug('tmp_fracs: {}'.format(tmp_fracs))
-                    logger.debug('tmp_fracs[obsBin+1]: {}'.format(tmp_fracs[obsBin+1]))
-                    logger.debug('tmp_fracs[obsBin+1].split("][end fraction]"): {}'.format(tmp_fracs[obsBin+1].split("][end fraction]")))
+                logger.debug('tmp_fracs: {}'.format(tmp_fracs))
+                logger.debug('tmp_fracs[1]: {}'.format(tmp_fracs[1]))
+                logger.debug('tmp_fracs[1].split("][end fraction]"): {}'.format(tmp_fracs[1].split("][end fraction]")))
 
-                    # The current for loop depends on how many times "[Bin fraction: " appears, when we run the `main_fiducialXSTemplates`
-                    tmpFrac = float(tmp_fracs[obsBin+1].split("][end fraction]")[0])
-                    if not math.isnan(tmpFrac):
-                        fractionBkg[tag_] = tmpFrac
-                    else:
-                        logger.error('total entries in the current bin is isnan. Please check...')
-                        #FIXME: should we exit program here or not???
+                # The current for loop depends on how many times "[Bin fraction: " appears, when we run the `main_fiducialXSTemplates`
+                tmpFrac = float(tmp_fracs[1].split("][end fraction]")[0])
+                if not math.isnan(tmpFrac):
+                    fractionBkg[tag_] = tmpFrac
+                else:
+                    logger.error('total entries in the current bin is isnan. Please check...')
+                    #FIXME: should we exit program here or not???
 
-                    if (('jet' in ListObsName[0] or 'jet' in ListObsName[1]) and tmpFrac!=0 and not math.isnan(tmpFrac)): # FIXME: this part will have issue when we have double differential obs.
-                        # FIXME: Check jets information, if its passing correctly or not.
-                        # FIXME: Again we are grabbing things from the log of `main_fiducialXSTemplates`. The next result depends on the couts of `main_fiducialXSTemplates`
-                        logger.debug('tmp_fracs[obsBin+1].split("Bin fraction (JESup): "): {}'.format(tmp_fracs[obsBin+1].split("Bin fraction (JESup): ")))
-                        logger.debug('tmp_fracs[obsBin+1].split("Bin fraction (JESup): ")[1]: {}'.format(tmp_fracs[obsBin+1].split("Bin fraction (JESup): ")[1]))
-                        logger.debug('tmp_fracs[obsBin+1].split("Bin fraction (JESup): ")[1].split("]"): {}'.format(tmp_fracs[obsBin+1].split("Bin fraction (JESup): ")[1].split("]")))
+                if (('jet' in ListObsName[0] or 'jet' in ListObsName[1]) and tmpFrac!=0 and not math.isnan(tmpFrac)): # FIXME: this part will have issue when we have double differential obs.
+                    # FIXME: Check jets information, if its passing correctly or not.
+                    # FIXME: Again we are grabbing things from the log of `main_fiducialXSTemplates`. The next result depends on the couts of `main_fiducialXSTemplates`
+                    logger.debug('tmp_fracs[1].split("Bin fraction (JESup): "): {}'.format(tmp_fracs[1].split("Bin fraction (JESup): ")))
+                    logger.debug('tmp_fracs[1].split("Bin fraction (JESup): ")[1]: {}'.format(tmp_fracs[1].split("Bin fraction (JESup): ")[1]))
+                    logger.debug('tmp_fracs[1].split("Bin fraction (JESup): ")[1].split("]"): {}'.format(tmp_fracs[1].split("Bin fraction (JESup): ")[1].split("]")))
 
-                        tmpFrac_up =float(tmp_fracs[obsBin+1].split("Bin fraction (JESup): ")[1].split("]")[0])
-                        tmpFrac_dn =float(tmp_fracs[obsBin+1].split("Bin fraction (JESdn): ")[1].split("]")[0])
-                        if not math.isnan(tmpFrac_up):
-                            lambdajesupBkg[tag_] = tmpFrac_up/tmpFrac - 1
-                        if not math.isnan(tmpFrac_dn):
-                            lambdajesdnBkg[tag_] = tmpFrac_dn/tmpFrac - 1
+                    tmpFrac_up =float(tmp_fracs[1].split("Bin fraction (JESup): ")[1].split("]")[0])
+                    tmpFrac_dn =float(tmp_fracs[1].split("Bin fraction (JESdn): ")[1].split("]")[0])
+                    if not math.isnan(tmpFrac_up):
+                        lambdajesupBkg[tag_] = tmpFrac_up/tmpFrac - 1
+                    if not math.isnan(tmpFrac_dn):
+                        lambdajesdnBkg[tag_] = tmpFrac_dn/tmpFrac - 1
 
     os.chdir(currentDir)
     logger.debug('observableBins: {}'.format(observableBins))

--- a/runHZZFiducialXS.py
+++ b/runHZZFiducialXS.py
@@ -170,8 +170,8 @@ def extractBackgroundTemplatesAndFractions(obsName, observableBins):
     # FIXME: directory name hardcoded
     currentDir = os.getcwd(); os.chdir('./templates/')
 
-    print("==> Compile the package main_fiducialXSTemplates...")
-    cmd = 'make'; processCmd(cmd, get_linenumber())
+    print("==> Remove the executable and Compile the package main_fiducialXSTemplates...")
+    cmd = 'rm main_fiducialXSTemplates; make'; processCmd(cmd, get_linenumber())
     DirectoryToCreate = 'templatesXS/DTreeXS_'+opt.OBSNAME+'/13TeV/'
     print('[INFO] Create directory: {}'.format(DirectoryToCreate))
     print('[INFO] compile the script inside the template directory')

--- a/runHZZFiducialXS.py
+++ b/runHZZFiducialXS.py
@@ -956,13 +956,13 @@ def runFiducialXS():
                 logger.debug("Extract results for physicsModel - {}, and modelName - {}".format(physicalModel, modelName))
                 resultsXS = extractResults(obsName, observableBins, modelName, physicalModel, asimovDataModelName, asimovPhysicalModel, resultsXS)
                 # plot the fit results
-                if ( (not obsName.startswith("mass4l")) and ("vs" not in obsName)): # INFO: Skip this plotter for 2D vars
+                if ( (not obsName.startswith("mass4l"))):
                     # identify 1D or 2D obs using `ListObsName` length
                     cmd = 'python python/plotAsimov_simultaneous.py -l -q -b --obsName="'+obsName+'" --obsBins="'+opt.OBSBINS+'" --asimovModel="'+asimovDataModelName+'" --unfoldModel="'+modelName+'" --obs='+str(len(ListObsName))# +' --lumiscale=str(opt.LUMISCALE)'
                     if (opt.UNBLIND): cmd = cmd + ' --unblind'
                     output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
                     print (output)
-                elif (physicalModel=="v2" and ("vs" not in obsName)): # INFO: Skip this plotter for 2D vars
+                elif (physicalModel=="v2"):
                     cmd = 'python python/plotAsimov_inclusive.py -l -q -b --obsName="'+obsName+'" --obsBins="'+opt.OBSBINS+'" --asimovModel="'+asimovDataModelName+'" --unfoldModel="'+modelName+'"' #+' --lumiscale=str(opt.LUMISCALE)'
                     if (opt.UNBLIND): cmd = cmd + ' --unblind'
                     output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
@@ -1054,22 +1054,22 @@ def runFiducialXS():
         output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
 
         # FIXME: Currently, produce plot is not working for 2D vars
-        if ("vs" in obsName): continue
-        for modelName in modelNames:
-            if (not opt.FIXMASS=="False"):
-                cmd = 'python python/producePlots.py -l -q -b --obsName="'+obsName.replace(' ','_')+'" --obsBins="'+opt.OBSBINS+'" --unfoldModel="'+modelName+'" --theoryMass="'+opt.FIXMASS+'"'
-            else:
+        if ("vs" not in obsName):
+            for modelName in modelNames:
+                if (not opt.FIXMASS=="False"):
+                    cmd = 'python python/producePlots.py -l -q -b --obsName="'+obsName.replace(' ','_')+'" --obsBins="'+opt.OBSBINS+'" --unfoldModel="'+modelName+'" --theoryMass="'+opt.FIXMASS+'"'
+                else:
+                    cmd = 'python python/producePlots.py -l -q -b --obsName="'+obsName.replace(' ','_')+'" --obsBins="'+opt.OBSBINS+'" --unfoldModel="'+modelName+'" --theoryMass="125.0"'
+                    ### FIXME: VUKASIN: Just until Higgs mass is properly implemented
                 cmd = 'python python/producePlots.py -l -q -b --obsName="'+obsName.replace(' ','_')+'" --obsBins="'+opt.OBSBINS+'" --unfoldModel="'+modelName+'" --theoryMass="125.0"'
-                ### FIXME: VUKASIN: Just until Higgs mass is properly implemented
-            cmd = 'python python/producePlots.py -l -q -b --obsName="'+obsName.replace(' ','_')+'" --obsBins="'+opt.OBSBINS+'" --unfoldModel="'+modelName+'" --theoryMass="125.0"'
 
-            if (opt.FIXFRAC): cmd = cmd + ' --fixFrac'
-            if (opt.UNBLIND): cmd = cmd + ' --unblind'
-            output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
-            print (output)
-            cmd = cmd + ' --setLog'
-            output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
-            print (output)
+                if (opt.FIXFRAC): cmd = cmd + ' --fixFrac'
+                if (opt.UNBLIND): cmd = cmd + ' --unblind'
+                output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
+                print (output)
+                cmd = cmd + ' --setLog'
+                output = processCmd(cmd, get_linenumber(), os.path.basename(__file__))
+                print (output)
 
 if __name__ == "__main__":
     runFiducialXS()

--- a/templates/fiducialXSTemplates.C
+++ b/templates/fiducialXSTemplates.C
@@ -438,7 +438,7 @@ int getTemplateXS(TString processNameTag, TString processFileName, TString sqrts
     if (obsName2 != ""){
         fLocation = templatesDir + "/" + PROCESSING_TYPE + "_" + obsName + "_vs_" + obsName2 + "/" + sqrtsTag + "/";
     }
-    std::cout << "[DEBUG: fiducialXSTemplates.C#441]  fLocation: " << fLocation << std::endl;
+    // std::cout << "[DEBUG: fiducialXSTemplates.C#441]  fLocation: " << fLocation << std::endl;
     TFile *fTemplateTree = new TFile(fLocation + "/" + templateNameTag + "_" + sfinalState + ".root", fOption);
     TTree* TT = new TTree("selectedEvents","selectedEvents");
 
@@ -580,7 +580,7 @@ void storeTreeAndTemplatesXS(TTree* TT, TString obsName, TString obsBinDn, TStri
     TString treeWeightedCut; treeWeightedCut = sWeight + treeCut;
     TT->Draw(treeReq.Data(), treeWeightedCut.Data(), "goff");
 
-    std::cout << "==>#582 fLocation: " << fLocation << std::endl;
+    // std::cout << "==>#582 fLocation: " << fLocation << std::endl;
     TString templateLocation = fLocation + "/" + templateNameTag + "_" + sfinalState + "_" + obsTag + ".root";
     TFile* fTemplate = new TFile(templateLocation, fOption);
     fTemplate->cd();
@@ -605,7 +605,7 @@ void storeTreeAndTemplatesXS(TTree *TT, TString obsName, TString obsBinDn, TStri
     TString obsTag = obsName + "_" + obsBinDn + "_" + obsBinUp;
     //  for second observable
     TString obsTag2 = obsName2 + "_" + obsBinDn2 + "_" + obsBinUp2;
-    TH1D *h1D = new TH1D("m4l_" + obsTag, "m4l_" + obsTag, nbinsX, CUT_M4LLOW, CUT_M4LHIGH);
+    TH1D *h1D = new TH1D("m4l_" + obsTag + "_" + obsTag2, "m4l_" + obsTag + "_" + obsTag2, nbinsX, CUT_M4LLOW, CUT_M4LHIGH);
 
     // adjust obsName for the selection, e.g. where abs(x) is required
     TString selectionObsName = "1";

--- a/templates/fiducialXSTemplates.C
+++ b/templates/fiducialXSTemplates.C
@@ -151,7 +151,7 @@ void templatesXS(TString processNameTag, TString processFileName, TString sqrtsT
 {
     analysisInit();
 
-    useRefit = false;
+    useRefit = false; // FIXME: we can remove this from here. It should be controlled from `runHZZFiducialXS.py`
 
     // produce XS 2D templates (uniform binning)
     cout << "======\n[INFO] preparing 2D XS templates, process: "+processNameTag+", sqrts: "+sqrtsTag+", Final State: ["<<sfinalState<<"]" << "["<<PROCESSING_TYPE<<"]" << "["<<CUT_M4LLOW<<" < m4l < "<<CUT_M4LHIGH<<"] " << endl;

--- a/templates/fiducialXSTemplates.C
+++ b/templates/fiducialXSTemplates.C
@@ -80,10 +80,10 @@ const unsigned int outNwidth = 16;
 TString PROCESSING_TYPE = "XSTree";// "XSTreeZ4l"
 
 void templatesXS(TString processNameTag, TString processFileName, TString sqrtsTag, TString sfinalState,
-                 TString obsName, TString obsBinDn, TString obsBinUp, TString fitTypeZ4l, bool useRefit);
+                 TString obsName, TString obsBinDn, TString obsBinUp, TString fitTypeZ4l, bool useRefit, TString obsName2, TString obsBinDn2, TString obsBinUp2);
 
 int getTemplateXS(TString processNameTag, TString processFileName, TString sqrtsTag, TString sfinalState,
-                  TString obsName, TString obsBinDn, TString obsBinUp, TString fitTypeZ4l, bool useRefit,
+                  TString obsName, TString obsBinDn, TString obsBinUp, TString obsName2, TString obsBinDn2, TString obsBinUp2, TString fitTypeZ4l, bool useRefit,
                   double elpT = CUT_ELPT, double mupT = CUT_MUPT, double mZ2_low = CUT_MZ2LOW,
                   double mZ1_low = CUT_MZ1LOW, double m4l_low = CUT_M4LLOW, double m4l_high = CUT_M4LHIGH);
 
@@ -95,6 +95,7 @@ TString strRandom(unsigned int rndmMax = 100000);
 void smoothAndNormaliseTemplate(TH2D* &h2D, bool silent = true);
 void smoothAndNormaliseTemplate1D(TH1D* &h1D, double norm = 1.);
 void storeTreeAndTemplatesXS(TTree* TT, TString obsName, TString obsBinDn, TString obsBinUp, TString sfinalState, TString fLocation, TString templateNameTag, TString fOption, TString fitTypeZ4l, bool useRefit);
+void storeTreeAndTemplatesXS(TTree *TT, TString obsName, TString obsBinDn, TString obsBinUp, TString sfinalState, TString fLocation, TString templateNameTag, TString fOption, TString fitTypeZ4l, bool useRefit, TString obsName2, TString obsBinDn2, TString obsBinUp2);
 int normaliseHist(TH2D* &h2D, double norm = 1.);
 int normaliseHist(TH1D* &h1D, double norm = 1.);
 int fillEmptyBinsHist2D(TH2D* &h2D, double floor = .00001);
@@ -111,7 +112,8 @@ double nEvents = -1;
 
 
 //_______________________________________________________________________________________________________________________________________________
-void fiducialXSTemplates(TString processNameTag = "qqZZ", TString processFileName = "ZZTo2e2mu_mZZ95-160.root", TString sfinalState = "4l", TString obsName = "massZ2", TString obsBinDn = "0", TString obsBinUp = "120", TString sqrtsTag = "8TeV", TString baseDirXS = "templatesXS", TString sProcessingType = "DTreeXS", TString fitTypeZ4l = "none", bool useRefit = false){
+void fiducialXSTemplates(TString processNameTag = "qqZZ", TString processFileName = "ZZTo2e2mu_mZZ95-160.root", TString sfinalState = "4l", TString obsName = "massZ1", TString obsBinDn = "0", TString obsBinUp = "120", TString sqrtsTag = "8TeV", TString baseDirXS = "templatesXS", TString sProcessingType = "DTreeXS", TString fitTypeZ4l = "none", bool useRefit = false,  TString obsName2 = "", TString obsBinDn2 = "", TString obsBinUp2 = "")
+{
     // prepare XS templates for given parameters
     PROCESSING_TYPE = sProcessingType;
     templatesDir = baseDirXS;
@@ -134,7 +136,7 @@ void fiducialXSTemplates(TString processNameTag = "qqZZ", TString processFileNam
         nbinsX=15;
     }
     cout<<"Begin templatesXS"<<endl;
-    templatesXS(processNameTag, processFileName, sqrtsTag, sfinalState, obsName, obsBinDn, obsBinUp, fitTypeZ4l, useRefit);
+    templatesXS(processNameTag, processFileName, sqrtsTag, sfinalState, obsName, obsBinDn, obsBinUp, fitTypeZ4l, useRefit, obsName2, obsBinDn2, obsBinUp2);
 }
 
 //_______________________________________________________________________________________________________________________________________________
@@ -145,8 +147,8 @@ void analysisInit() {
 
 //_______________________________________________________________________________________________________________________________________________
 void templatesXS(TString processNameTag, TString processFileName, TString sqrtsTag, TString sfinalState,
-                 TString obsName, TString obsBinDn, TString obsBinUp, TString fitTypeZ4l, bool useRefit) {
-
+                 TString obsName, TString obsBinDn, TString obsBinUp, TString fitTypeZ4l, bool useRefit, TString obsName2, TString obsBinDn2, TString obsBinUp2)
+{
     analysisInit();
 
     useRefit = false;
@@ -156,11 +158,13 @@ void templatesXS(TString processNameTag, TString processFileName, TString sqrtsT
     cout<<"[INFO] fitType: "<<fitTypeZ4l<<" templatesXS using refit? "<<useRefit<<endl;
 
     if (sfinalState == "4l") {
-        getTemplateXS(processNameTag, processFileName, sqrtsTag, "2e2mu", obsName, obsBinDn, obsBinUp, fitTypeZ4l, useRefit);
-        getTemplateXS(processNameTag, processFileName, sqrtsTag, "4e", obsName, obsBinDn, obsBinUp, fitTypeZ4l, useRefit);
-        getTemplateXS(processNameTag, processFileName, sqrtsTag, "4mu", obsName, obsBinDn, obsBinUp, fitTypeZ4l, useRefit);
-    } else {
-        getTemplateXS(processNameTag, processFileName, sqrtsTag, sfinalState, obsName, obsBinDn, obsBinUp, fitTypeZ4l, useRefit);
+        getTemplateXS(processNameTag, processFileName, sqrtsTag, "2e2mu", obsName, obsBinDn, obsBinUp, obsName2, obsBinDn2, obsBinUp2, fitTypeZ4l, useRefit);
+        getTemplateXS(processNameTag, processFileName, sqrtsTag, "4e", obsName, obsBinDn, obsBinUp, obsName2, obsBinDn2, obsBinUp2, fitTypeZ4l, useRefit);
+        getTemplateXS(processNameTag, processFileName, sqrtsTag, "4mu", obsName, obsBinDn, obsBinUp, obsName2, obsBinDn2, obsBinUp2, fitTypeZ4l, useRefit);
+    }
+    else
+    {
+        getTemplateXS(processNameTag, processFileName, sqrtsTag, sfinalState, obsName, obsBinDn, obsBinUp, obsName2, obsBinDn2, obsBinUp2, fitTypeZ4l, useRefit);
     }
 }
 
@@ -403,9 +407,9 @@ int getHistTreesXS(TChain* tree, TString processNameTag, TString sqrtsTag, TTree
 //_______________________________________________________________________________________________________________________________________________
 // using the fixed floor at the moment, to be changed
 int getTemplateXS(TString processNameTag, TString processFileName, TString sqrtsTag, TString sfinalState,
-                  TString obsName, TString obsBinDn, TString obsBinUp, TString fitTypeZ4l, bool useRefit,
-                  double elpT, double mupT, double mZ2_low, double mZ1_low, double m4l_low, double m4l_high) {
-
+                  TString obsName, TString obsBinDn, TString obsBinUp, TString obsName2, TString obsBinDn2, TString obsBinUp2, TString fitTypeZ4l, bool useRefit,
+                  double elpT, double mupT, double mZ2_low, double mZ1_low, double m4l_low, double m4l_high)
+{
     // prepare final state variables (for loop, later also plotting)
     unsigned int iFinState;
     if      (sfinalState == "4mu")   {iFinState = 1;}
@@ -416,6 +420,7 @@ int getTemplateXS(TString processNameTag, TString processFileName, TString sqrts
 
     // get chains
     TChain* sigTree;
+    // FIXME: Hardcoded tree names???
     if (processNameTag == "Data") {
         sigTree = new TChain("Ana/passedEvents");
     } else if (processNameTag == "ZJetsCR") {
@@ -430,7 +435,11 @@ int getTemplateXS(TString processNameTag, TString processFileName, TString sqrts
     TString fOption = "RECREATE";
     TString templateNameTag = getTemplateNameTag(processNameTag);
     TString fLocation = templatesDir+"/"+PROCESSING_TYPE+"_"+obsName+"/"+sqrtsTag+"/";
-    TFile* fTemplateTree = new TFile(fLocation+"/"+templateNameTag+"_"+sfinalState+".root", fOption);
+    if (obsName2 != ""){
+        fLocation = templatesDir + "/" + PROCESSING_TYPE + "_" + obsName + "_vs_" + obsName2 + "/" + sqrtsTag + "/";
+    }
+    std::cout << "[DEBUG: fiducialXSTemplates.C#441]  fLocation: " << fLocation << std::endl;
+    TFile *fTemplateTree = new TFile(fLocation + "/" + templateNameTag + "_" + sfinalState + ".root", fOption);
     TTree* TT = new TTree("selectedEvents","selectedEvents");
 
     //nEvents
@@ -463,7 +472,7 @@ int getTemplateXS(TString processNameTag, TString processFileName, TString sqrts
     // TString fLocation = templatesDir+"/"+PROCESSING_TYPE+"_"+obsName+"/"+sqrtsTag+"/";
     // TString fOption = "RECREATE";
     cout<<"obsBinDn "<<obsBinDn<<" obsBinUp "<<obsBinUp<<endl;
-    if (obsBinDn==obsBinUp && obsBinDn.Contains("|")) { // if bin boundaries are passed - get the  boundaries in TObjArray and loop
+    if (obsBinDn==obsBinUp && obsBinDn.Contains("|") && obsBinDn2 == "") { // if bin boundaries are passed - get the  boundaries in TObjArray and loop
         TObjArray* ta = (TObjArray*) obsBinDn.Tokenize("|");
         for (int kEntry = 0; kEntry < ta->GetEntries() - 1; kEntry++){
             TString obsBinDn = ((TObjString*) ta->At(kEntry))->GetString();
@@ -471,7 +480,24 @@ int getTemplateXS(TString processNameTag, TString processFileName, TString sqrts
             cout<<"test1: "<<endl;
             storeTreeAndTemplatesXS(TT, obsName, obsBinDn, obsBinUp, sfinalState, fLocation, templateNameTag, fOption, fitTypeZ4l, useRefit);
         }
+    }
+    else if (obsBinDn == obsBinUp && obsBinDn.Contains("|") && obsBinDn2 == obsBinUp2)
+    {
+        TObjArray *ta = (TObjArray *)obsBinDn.Tokenize("|");
+        TObjArray *ta2 = (TObjArray *)obsBinDn2.Tokenize("|");
+        TString obsBinDn2 = ((TObjString *)ta2->At(0))->GetString();
+        TString obsBinUp2 = ((TObjString *)ta2->At(0 + 1))->GetString();
+        cout << "obsBinDn2, obsBinUp2 is....: " << obsBinDn2 << "\t" << obsBinUp2 << endl;
+        for (int kEntry = 0; kEntry < ta->GetEntries() - 1; kEntry++)
+        {
+            TString obsBinDn = ((TObjString *)ta->At(kEntry))->GetString();
+            TString obsBinUp = ((TObjString *)ta->At(kEntry + 1))->GetString();
+            cout << "[DEBUG]#502:  " << endl;
+            storeTreeAndTemplatesXS(TT, obsName, obsBinDn, obsBinUp, sfinalState, fLocation, templateNameTag, fOption, fitTypeZ4l, useRefit, obsName2, obsBinDn2, obsBinUp2);
+        }
     } else { // if one set of up & down bin boundaries is passed - run for it
+        // FIXME: Add the else statement for both 1D and 2D
+        // if one set of up & down bin boundaries is passed - run for itate, fLocation, templateNameTag, fOption, fitTypeZ4l, useRefit);
         cout<<"test1: "<<endl;
         storeTreeAndTemplatesXS(TT, obsName, obsBinDn, obsBinUp, sfinalState, fLocation, templateNameTag, fOption, fitTypeZ4l, useRefit);
     }
@@ -554,7 +580,8 @@ void storeTreeAndTemplatesXS(TTree* TT, TString obsName, TString obsBinDn, TStri
     TString treeWeightedCut; treeWeightedCut = sWeight + treeCut;
     TT->Draw(treeReq.Data(), treeWeightedCut.Data(), "goff");
 
-    TString templateLocation = fLocation+"/"+templateNameTag+"_"+sfinalState+"_"+obsTag+".root";
+    std::cout << "==>#582 fLocation: " << fLocation << std::endl;
+    TString templateLocation = fLocation + "/" + templateNameTag + "_" + sfinalState + "_" + obsTag + ".root";
     TFile* fTemplate = new TFile(templateLocation, fOption);
     fTemplate->cd();
     h1D->GetXaxis()->SetTitle("CMS_zz4l_mass");
@@ -565,6 +592,138 @@ void storeTreeAndTemplatesXS(TTree* TT, TString obsName, TString obsBinDn, TStri
         //if (templateNameTag == "XSBackground_ZJetsCR") {
         //    for (int k = 0; k < 5; k++) smoothAndNormaliseTemplate1D(h1D); // once again 5-smoothing
         // }
+    }
+
+    h1D->Write();
+    fTemplate->Close();
+    h1D->Delete();
+}
+
+//_______________________________________________________________________________________________________________________________________________
+void storeTreeAndTemplatesXS(TTree *TT, TString obsName, TString obsBinDn, TString obsBinUp, TString sfinalState, TString fLocation, TString templateNameTag, TString fOption, TString fitTypeZ4l, bool useRefit, TString obsName2, TString obsBinDn2, TString obsBinUp2)
+{
+    TString obsTag = obsName + "_" + obsBinDn + "_" + obsBinUp;
+    //  for second observable
+    TString obsTag2 = obsName2 + "_" + obsBinDn2 + "_" + obsBinUp2;
+    TH1D *h1D = new TH1D("m4l_" + obsTag, "m4l_" + obsTag, nbinsX, CUT_M4LLOW, CUT_M4LHIGH);
+
+    // adjust obsName for the selection, e.g. where abs(x) is required
+    TString selectionObsName = "1";
+    TString selectionObsName2 = "1";
+
+    if (obsName == "costhetastar")
+    {
+        selectionObsName = "abs(cosThetaStar)";
+    }
+    else if (obsName == "cosThetaStar")
+    {
+        selectionObsName = "abs(cosThetaStar)";
+    }
+    else if (obsName == "cosTheta1")
+    {
+        selectionObsName = "abs(cosTheta1)";
+    }
+    else if (obsName == "costheta1")
+    {
+        selectionObsName = "abs(cosTheta1)";
+    }
+    else if (obsName == "costheta2")
+    {
+        selectionObsName = "abs(cosTheta2)";
+    }
+    else if (obsName == "cosTheta2")
+    {
+        selectionObsName = "abs(cosTheta2)";
+    }
+    else if (obsName == "Phi")
+    {
+        selectionObsName = "abs(Phi)";
+    }
+    else if (obsName == "phi")
+    {
+        selectionObsName = "abs(Phi)";
+    }
+    else if (obsName == "Phi1")
+    {
+        selectionObsName = "abs(Phi1)";
+    }
+    else if (obsName == "phi1")
+    {
+        selectionObsName = "abs(Phi1)";
+    }
+    else if (obsName == "eta4l")
+    {
+        selectionObsName = "abs(eta4l)";
+    }
+    else if (obsName == "rapidity4l")
+    {
+        selectionObsName = "abs(rapidity4l)";
+    }
+    else if (obsName == "inclusive")
+    {
+        selectionObsName = "pT4l";
+    }
+    else
+    {
+        selectionObsName = obsName;
+    }
+    // second observable
+    selectionObsName2 = obsName2;
+
+    // prepare cuts and get hist from the tree->Draw()
+    // TString treeCut = "((" + obsBinDn + " <= "+selectionObsName+") && ("+selectionObsName+" < " + obsBinUp + "))";
+    TString treeCut1 = "((" + obsBinDn + " <= " + selectionObsName + ") && (" + selectionObsName + " < " + obsBinUp + "))";
+    cout << "[  Tree cut 1 is............ " << treeCut1 << "]" << endl;
+    TString treeCut2 = "((" + obsBinDn2 + " <= " + selectionObsName2 + ") && (" + selectionObsName2 + " < " + obsBinUp2 + "))";
+    cout << "[  Tree cut 2 is............ " << treeCut2 << "]" << endl;
+    TString treeCut = "(" + treeCut1 + " && " + treeCut2 + ")"; // joint cut
+    cout << "[  Tree cut is............ " << treeCut << "]" << endl;
+    TString sM4l = "";
+    if (useRefit)
+    {
+        sM4l = "mass4lREFIT>>m4l_";
+    }
+    else
+    {
+        sM4l = "mass4l>>m4l_";
+    }
+    TString treeReq;
+    treeReq = sM4l + obsTag;
+    double entriesTot = TT->GetEntries();
+    double entriesBin = TT->GetEntries(treeCut);
+    double fracBin = (double)entriesBin / entriesTot;
+    cout << "[Observable tag: " << obsTag << "]" << endl;
+    cout << "[Tree and templates saved in: " << fLocation << "]" << endl;
+    cout << "[Bin fraction: " << fracBin << "][end fraction]" << endl;
+    if (obsName.Contains("jet"))
+    { // assumes obserbale name in form "njets_pt{pt}_eta{eta}"
+        TString treeCut_jesdn = "((" + obsBinDn + " <= " + obsName + "_jesdn) && (" + obsName + "_jesdn < " + obsBinUp + "))";
+        double entriesBin_jesdn = TT->GetEntries(treeCut_jesdn);
+        double fracBin_jesdn = (double)entriesBin_jesdn / entriesTot;
+        TString treeCut_jesup = "((" + obsBinDn + " <= " + obsName + "_jesup) && (" + obsName + "_jesup < " + obsBinUp + "))";
+        double entriesBin_jesup = TT->GetEntries(treeCut_jesup);
+        double fracBin_jesup = (double)entriesBin_jesup / entriesTot;
+        cout << "[Bin fraction (JESdn): " << fracBin_jesdn << "]" << endl;
+        cout << "[Bin fraction (JESup): " << fracBin_jesup << "]" << endl;
+    }
+
+    TString sWeight = "weight*";
+    TString treeWeightedCut;
+    treeWeightedCut = sWeight + treeCut;
+    TT->Draw(treeReq.Data(), treeWeightedCut.Data(), "goff");
+
+    TString templateLocation = fLocation + "/" + templateNameTag + "_" + sfinalState + "_" + obsTag + "_" + obsTag2 + ".root";
+    TFile *fTemplate = new TFile(templateLocation, fOption);
+    fTemplate->cd();
+    h1D->GetXaxis()->SetTitle("CMS_zz4l_mass");
+
+    if (fitTypeZ4l != "doHighMass")
+    {
+        // for (int k = 0; k < 5; k++)
+        smoothAndNormaliseTemplate1D(h1D); // 5-smoothing
+        // if (templateNameTag == "XSBackground_ZJetsCR") {
+        //     for (int k = 0; k < 5; k++) smoothAndNormaliseTemplate1D(h1D); // once again 5-smoothing
+        //  }
     }
 
     h1D->Write();

--- a/templates/main_fiducialXSTemplates.cpp
+++ b/templates/main_fiducialXSTemplates.cpp
@@ -9,8 +9,8 @@ int main(int argc, char* argv[])
 
     cout<<"argc "<<argc<<" argv[11] "<<argv[11]<<endl;
 
-	if(argc != 10 && argc != 11 && argc !=12)
-		return 1;
+    if (argc != 10 && argc != 11 && argc != 12 && argc != 15)
+        return 1;
 
     if(argc == 10)
         fiducialXSTemplates(argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], argv[9]);
@@ -21,5 +21,8 @@ int main(int argc, char* argv[])
     if(argc == 12)
         fiducialXSTemplates(argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], argv[9], argv[10], argv[11]);
 
-	return 0;
+    if (argc == 15)
+        fiducialXSTemplates(argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], argv[9], argv[10], argv[11], argv[12], argv[13], argv[14]);
+
+    return 0;
 }


### PR DESCRIPTION
### Summary of PR

1. This version is tested with
    1. 1D obs: `mass4l` and `pT4l`
    2. 2D obs: `massZ1 vs massZ2`
 
2. Added logger
    1. Now, instead of print we can use “[logger.info](http://logger.info/)()” or “logger.debug()”, etc
        1. Main feature is that it automatically provides filename, module name, function name and line number of the corresponding file where its called. Example:
         
        ```python
        logger.debug("Obs Name: {}\t Bins: {}".format(obsName, observableBins))
        ```
        
        Then it will give you output like below on terminal: 
        ```bash
         [DEBUG] - [runHZZFiducialXS.py:#124] - [extractBackgroundTemplatesAndFractions; runHZZFiducialXS] - [INFO] Obs Name: mass4l         	Bins: ['105.0', '140.0']
         ```
3. Added new key “ifAbs” in the YAML file to handle absolute value. Currently, its not used in the program. We can use this later at appropriate places. (Not relevant for the moment)

### To-Do:

1. Compare cards for mass4l and pT with new and old implementation
    1. Also, compare the workspaces
2. Fix the plotters... Currently, I commented them. (May be in next PR)
3. Currently, the interpolation part only run for 1D measurement. Need to discuss/think about the implementation.

### Possible next PR:

1. Remove the 8TeV WS root file calling. Its not difficult to get rid of this. It may take ~1hr to fix this.