### PR TITLE
Adding the separation per data taking period: Part I - Efficiency and uncertainty modules

### DIFF
--- a/RunEverything.py
+++ b/RunEverything.py
@@ -71,9 +71,9 @@ with open(InputYAMLFile, 'r') as ymlfile:
                 border_msg("Running efficiencies step: "+ obsName)
                 for channel in args.channels:
                     logger.info("==> channel: {}".format(channel))
-                    command = 'nohup python -u efficiencyFactors.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -c "{channel}" >& log/effs_{obsName_log}_{channel}.log &'.format(
+                    command = 'nohup python -u efficiencyFactors.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -c "{channel}" -y "{year}" >& log/effs_{obsName_log}_{channel}.log &'.format(
                     # command = 'python -u efficiencyFactors.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -c "{channel}"'.format(
-                        obsName = obsName, obsBins = obsBin['bins'], channel = channel, obsName_log = obsName.replace(" ","_")
+                        obsName = obsName, obsBins = obsBin['bins'], channel = channel, year = args.year, obsName_log = obsName.replace(" ","_")
                     )
                     logger.info("Command: {}".format(command))
                     if (args.RunCommand): os.system(command)
@@ -105,8 +105,8 @@ with open(InputYAMLFile, 'r') as ymlfile:
             if (args.step == 4):
                 border_msg("Running getUnc")
                 # command = 'python -u getUnc_Unc.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" >& log/unc_{obsName}.log &'.format(
-                command = 'python -u getUnc_Unc.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}"'.format(
-                        obsName = obsName, obsBins = obsBin['bins']
+                command = 'python -u getUnc_Unc.py -l -q -b --obsName="{obsName}" --obsBins="{obsBins}" -y "{year}"'.format(
+                        obsName = obsName, obsBins = obsBin['bins'], year = args.year
                 )
                 logger.info("Command: {}".format(command))
                 if (args.RunCommand): os.system(command)

--- a/efficiencyFactors.py
+++ b/efficiencyFactors.py
@@ -300,18 +300,22 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
         # Reco observable cut - if using the _jesup/down variations
 
         if (("jet" in obs_reco.lower()) or ("jet" in obs_reco2.lower())):
-            cutobs_reco_jesup = "("+obs_reco+"_jesup"+">="+str(obs_reco_low)+" && "+obs_reco+"_jesup"+"<"+str(obs_reco_high)+")"
-            cutobs_reco_jesdn = "("+obs_reco+"_jesdn"+">="+str(obs_reco_low)+" && "+obs_reco+"_jesdn"+"<"+str(obs_reco_high)+")"
+            cutobs_reco_jesup = ''
+            cutobs_reco_jesdn = ''
 
-            if obs_reco_high == "inf":
-                cutobs_reco_jesup = "("+obs_reco+"_jesup"+">="+str(obs_reco_low)+")"
-                cutobs_reco_jesdn = "("+obs_reco+"_jesdn"+">="+str(obs_reco_low)+")"
+            if ("jet" in obs_reco.lower()):
+                cutobs_reco_jesup = "("+obs_reco+"_jesup"+">="+str(obs_reco_low)+" && "+obs_reco+"_jesup"+"<"+str(obs_reco_high)+")"
+                cutobs_reco_jesdn = "("+obs_reco+"_jesdn"+">="+str(obs_reco_low)+" && "+obs_reco+"_jesdn"+"<"+str(obs_reco_high)+")"
+
+                if obs_reco_high == "inf":
+                    cutobs_reco_jesup = "("+obs_reco+"_jesup"+">="+str(obs_reco_low)+")"
+                    cutobs_reco_jesdn = "("+obs_reco+"_jesdn"+">="+str(obs_reco_low)+")"
            
             # Double differential measurement addition: Reco observable cut - if using the _jesup/down variations
             tmp_up = ''
             tmp_dn = ''
 
-            if not (obs_reco2 == ''):
+            if (not (obs_reco2 == '')) and ("jet" in obs_reco2.lower()) :
                 tmp_up = " && ("+obs_reco2+"_jesup"+">="+str(obs_reco2_low)+" && "+obs_reco2+"_jesup"+"<"+str(obs_reco2_high)+")"
                 tmp_dn = " && ("+obs_reco2+"_jesdn"+">="+str(obs_reco2_low)+" && "+obs_reco2+"_jesdn"+"<"+str(obs_reco2_high)+")"
 

--- a/efficiencyFactors.py
+++ b/efficiencyFactors.py
@@ -14,9 +14,6 @@ from sample_shortnames import *
 from Utils import *
 from read_bins import *
 
-if not os.path.isdir(datacardInputs):
-    os.mkdir(datacardInputs)
-
 grootargs = []
 def callback_rootargs(option, opt, value, parser):
     grootargs.append(opt)
@@ -114,9 +111,9 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
     gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libHiggsAnalysisCombinedLimit.so")
     gSystem.AddIncludePath("-I$ROOFITSYS/include")
 
-    logging.info(sample)
-    if ("NNLOPS" in sample or "nnlops" in sample):
-        print ("Will skip: "+ sample)
+    #logging.info(sample) - Comment: Not needed? VM
+    #if ("NNLOPS" in sample or "nnlops" in sample):
+    #    print ("Will skip: "+ sample)
     
     recoweight = "genWeight*pileupWeight*dataMCWeight"
 
@@ -211,7 +208,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
             border_msg("Sample: "+Sample+"\t Observable: "+str(obs_reco)+"\trecobin: "+str(recobin)+"\tgenbin: "+str(genbin))
 
         if ("NNLOPS" in Sample or "nnlops" in Sample):
-            print ("Skipping: "+ sample)
+            print ("Skipping: "+ Sample)
             #VM: For discussion: This can be removed as it is gonna continue anyway
             #recoweight = "genWeight*pileupWeight*dataMCWeight"
             continue
@@ -222,7 +219,7 @@ def geteffs(channel, SampleList, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen,
         if (not Tree[Sample]): continue
         i_sample = i_sample+1
 
-        shortname = sample_shortnames[Sample]
+        shortname = sample_shortnames[opt.ERA][Sample]
         processBin = shortname+'_'+channel+'_'+opt.OBSNAME+'_genbin'+str(genbin)+'_recobin'+str(recobin)
 
         if not (obs_reco2 == ''):
@@ -902,8 +899,10 @@ print("[INFO] obs_gen2  is  : {}".format(obs_gen2))
 
 obs_bins = read_bins(opt.OBSBINS)
 
+RootFile, Tree, nEvents, sumw = GrabMCTrees(opt.ERA)
+
 SampleList = []
-for long, short in sample_shortnames.iteritems():
+for long, short in sample_shortnames[opt.ERA].iteritems():
     #if (not ("WH" in short) or ("ttH" in short) or ("ZH" in short)): continue
     #if (not ("ggH" in short)): continue
     #if (not "VBF" in short): continue
@@ -925,7 +924,6 @@ Nbins = len(obs_bins)
 if obs_reco2 == '':
     Nbins = Nbins - 1 #  For the double diff measurement the len(obs_bins) is the actual number of bins, while for the 1 observable we parse bin edges so it needs to be len -1
     
-
 for chan in chans:
     for recobin in range(Nbins):
         for genbin in range(Nbins):
@@ -940,7 +938,11 @@ ext=''
 if (not opt.CHAN==''):
     ext='_'+opt.CHAN
 
-output_file_name = datacardInputs+'/inputs_sig_'+label+ext+'.py'
+
+if not os.path.isdir(opt.ERA): os.mkdir(opt.ERA)
+if not os.path.isdir(opt.ERA+"/"+datacardInputs): os.mkdir(opt.ERA+"/"+datacardInputs)
+
+output_file_name = opt.ERA+"/"+datacardInputs+'/inputs_sig_'+label+ext+'.py'
 
 
 with open(output_file_name, 'w') as f:
@@ -961,10 +963,10 @@ with open(output_file_name, 'w') as f:
     f.write('lambdajesdn = '+str(lambdajesdn)+' \n')
 
 
-more_output_file_name = datacardInputs+'/moreinputs_sig_'+opt.OBSNAME+ext+'.py'
+more_output_file_name = opt.ERA+'/'+datacardInputs+'/moreinputs_sig_'+opt.OBSNAME+ext+'.py'
 
 if not (obs_reco2 == ''):
-    more_output_file_name = datacardInputs+'/moreinputs_sig_'+opt.OBSNAME.replace(" ", "_")+'.py'
+    more_output_file_name = opt.ERA+'/'+datacardInputs+'/moreinputs_sig_'+opt.OBSNAME.replace(" ", "_")+'.py'
 
 
 with open(more_output_file_name, 'w') as f:
@@ -976,4 +978,4 @@ with open(more_output_file_name, 'w') as f:
     f.write('dfolding = '+str(dfolding)+' \n')
     #f.write('effanyreco = '+str(effanyreco)+' \n')
     #f.write('deffanyreco = '+str(deffanyreco)+' \n')
-print "All samples in all process bins compiled!"
+print("All samples in all process bins compiled!")

--- a/getUnc_Unc.py
+++ b/getUnc_Unc.py
@@ -122,10 +122,10 @@ def getunc(channel, List, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen, obs_bi
         if (not Sample in Tree): continue
         if (not Tree[Sample]): continue
 
-        if (obs_reco.startswith("njets")) or (obs_gen_high == "inf"):
+        if (obs_reco.startswith("njets") and obs_reco2 == '') or (obs_gen_high == "inf"):
             cutobs_gen = "("+obs_gen+">="+str(obs_gen_low)+")"
 
-            if (obs_reco2.startswith("njets")) or (obs_gen2_high == "inf"):
+            if (obs_gen2_high == "inf"):
                 cutobs_gen  += "&& ("+obs_gen2+">="+str(obs_gen2_low)+")"
             else:
                 cutobs_gen += "&& ("+obs_gen2+">="+str(obs_gen2_low)+" && "+obs_gen2+"<"+str(obs_gen2_high)+")"
@@ -133,7 +133,7 @@ def getunc(channel, List, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen, obs_bi
             cutobs_gen = "("+obs_gen+">="+str(obs_gen_low)+" && "+obs_gen+"<"+str(obs_gen_high)+")"
 
             if not (obs_reco2 == ''):
-                if obs_gen2_high == "inf":
+                if (obs_gen2_high == "inf"): 
                     cutobs_gen += "&& ("+obs_gen2+">="+str(obs_gen2_low)+")"
                 else:
                     cutobs_gen += "&& ("+obs_gen2+">="+str(obs_gen2_low)+" && "+obs_gen2+"<"+str(obs_gen2_high)+")"

--- a/getUnc_Unc.py
+++ b/getUnc_Unc.py
@@ -30,6 +30,7 @@ def parseOptions():
     parser.add_option('',   '--obsBins',dest='OBSBINS',    type='string',default='',   help='Bin boundaries for the diff. measurement separated by "|", e.g. as "|0|50|100|", use the defalut if empty string')
     parser.add_option('-f', '--doFit', action="store_true", dest='DOFIT', default=False, help='doFit, default false')
     parser.add_option('-p', '--doPlots', action="store_true", dest='DOPLOTS', default=False, help='doPlots, default false')
+    parser.add_option('-y', '--year', dest="ERA", type = 'string', default = '2018', help='Specifies the data taking period')
     parser.add_option("-l",action="callback",callback=callback_rootargs)
     parser.add_option("-q",action="callback",callback=callback_rootargs)
     parser.add_option("-b",action="callback",callback=callback_rootargs)
@@ -51,6 +52,7 @@ doPlots = opt.DOPLOTS
 
 if (not os.path.exists("plots") and doPlots):
     os.system("mkdir plots")
+    os.system('mkdir plots/'+opt.ERA)
 
 RooMsgService.instance().setGlobalKillBelow(RooFit.WARNING)
 
@@ -174,7 +176,7 @@ def getunc(channel, List, m4l_bins, m4l_low, m4l_high, obs_reco, obs_gen, obs_bi
             if (channel == "2e2mu"):
                 cutchan_gen_out  = "((GENZ_MomId[0]==25 && (GENZ_DaughtersId[0]==11 || GENZ_DaughtersId[0]==13) && GENZ_MomId[1]==25 && (GENZ_DaughtersId[1]==11 || GENZ_DaughtersId[1]==13) && GENZ_DaughtersId[0]!=GENZ_DaughtersId[1]) || (GENZ_MomId[0]==25 && (GENZ_DaughtersId[0]==11 || GENZ_DaughtersId[0]==13) && GENZ_MomId[2]==25 && (GENZ_DaughtersId[2]==11 || GENZ_DaughtersId[2]==13) && GENZ_DaughtersId[0]!=GENZ_DaughtersId[2]) || (GENZ_MomId[1]==25 && (GENZ_DaughtersId[1]==11 || GENZ_DaughtersId[1]==13) && GENZ_MomId[2]==25 && (GENZ_DaughtersId[2]==11 || GENZ_DaughtersId[2]==13) && GENZ_DaughtersId[1]!=GENZ_DaughtersId[2]))"
 
-        shortname = sample_shortnames[Sample]
+        shortname = sample_shortnames[opt.ERA][Sample]
         processBin = shortname+'_'+channel+'_'+opt.OBSNAME+'_genbin'+str(genbin)
 
         if not (obs_reco2 == ''):
@@ -337,8 +339,10 @@ print("[INFO] obs_gen is  : {}".format(obs_gen))
 #obs_bins = {0:(opt.OBSBINS.split("|")[1:((len(opt.OBSBINS)-1)/2)]),1:['0','inf']}[opt.OBSNAME=='inclusive']
 obs_bins = read_bins(opt.OBSBINS)
 
+RootFile, Tree, nEvents, sumw = GrabMCTrees(opt.ERA)
+
 List = []
-for long, short in sample_shortnames.iteritems():
+for long, short in sample_shortnames[opt.ERA].iteritems():
     if (not "ggH" in short): continue
     List.append(long)
 
@@ -361,14 +365,14 @@ if (obs_reco.startswith("njets")):
     for chan in chans:
         for genbin in range(len(obs_bins)-2): # last bin is >=3
             for Sample in List:
-                shortname = sample_shortnames[Sample]
+                shortname = sample_shortnames[opt.ERA][Sample]
                 processBin = shortname+'_'+chan+'_'+obs_reco+'_genbin'+str(genbin)
                 processBinPlus1 = shortname+'_'+chan+'_'+obs_reco+'_genbin'+str(genbin+1)
                 acceptance[processBin] = acceptance[processBin]-acceptance[processBinPlus1]
                 qcdUncert[processBin]['uncerUp'] = sqrt(qcdUncert[processBin]['uncerUp']*qcdUncert[processBin]['uncerUp']+qcdUncert[processBinPlus1]['uncerUp']*qcdUncert[processBinPlus1]['uncerUp'])
                 qcdUncert[processBin]['uncerDn'] = sqrt(qcdUncert[processBin]['uncerDn']*qcdUncert[processBin]['uncerDn']+qcdUncert[processBinPlus1]['uncerDn']*qcdUncert[processBinPlus1]['uncerDn'])
 
-DirForUncFiles = "python"
+DirForUncFiles = opt.ERA
 if not os.path.isdir(DirForUncFiles): os.mkdir(DirForUncFiles)
 with open(DirForUncFiles+'/accUnc_'+opt.OBSNAME.replace(" ","_")+'.py', 'w') as f:
     f.write('acc = '+str(acceptance)+' \n')

--- a/python/LoadData.py
+++ b/python/LoadData.py
@@ -3,18 +3,18 @@ from array import array
 import os
 from Utils import *
 
-dirMC_94 = '/raid/raid9/qguo/combine/2018_MC_Ntuple/'
-dirMC_94 = '/publicfs/cms/user/qyguo/ufl_machine/tools/combine/2018_MC_Ntuple/'
-#dirMC_94 = 'root://eosuser.cern.ch//eos/cms/store/group/phys_muon/TagAndProbe/HZZ4L/2018/'
-dirMC_94 = '/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/'
-dirMC_94_1 = '/raid/raid7/tjavaid/sig_samples_mc/'    # after copying to the local from Lucien working directory
-dirMC_94_Mad = '/raid/raid9/qguo/Run2/after/Run2_2/new/CMSSW_10_2_18/src/'
-dirData_94 = 'root://cmsio5.rc.ufl.edu//store/user/t2/users/klo/Higgs/HZZ4l/NTuple/Run2/MC80X_M17_4l_Feb21/'  # /cms/data/store/user/t2/users/archived/dsperka/Run2/Zprime/2017/rootfiles_Data_Apr16/  #to be added
+dirMC = {}
 
-border_msg("samples directory: "+dirMC_94)
+dirMC['2018'] = '/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/'
+dirMC['2017'] = '/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/' # 2018 for now until we sort out the locations
+dirMC['2016'] = '/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/' # 2018 for now until we sort out the locations
 
+dirData_94 = '/eos/home-v/vmilosev/Skim_2018_HZZ/WoW/'  
 
-SamplesMC_94 = [
+border_msg("samples directory: "+dirMC['2018'])
+
+SamplesMC = {}
+SamplesMC['2018'] = [
 #File missing or needs to be redirected (Vukasin)'GluGluHToZZTo4L_M125_13TeV_powheg2_minloHJ_NNLOPS_JHUgenV702_pythia8.root',   # path needs to be redirected
 ###
 'GluGluHToZZTo4L_M124_2018_slimmed.root',
@@ -30,67 +30,51 @@ SamplesMC_94 = [
 #'ttH_p.root'
 ]
 
-SamplesData_94 = [
+SamplesData = {}
+
+SamplesData['2017'] = [
 'DoubleEG_Run2017B-17Nov2017-v1.root','DoubleEG_Run2017C-17Nov2017-v1.root','DoubleEG_Run2017D-17Nov2017-v1.root','DoubleEG_Run2017E-17Nov2017-v1.root','DoubleEG_Run2017F-17Nov2017-v1.root',
 'DoubleMuon_Run2017-17Nov2017-v1.root','DoubleMuon_Run2017B-17Nov2017-v1.root','DoubleMuon_Run2017C-17Nov2017-v1.root'
 ]
 
 
-RootFile = {}
-Tree = {}
-nEvents = {}
-sumw = {}
-
-for i in range(0,len(SamplesMC_94)):
-
-    sample = SamplesMC_94[i].rstrip('.root')
 
 
-    if ("NNLOPS" in sample):
-        RootFile[sample] = TFile(dirMC_94_1+'/'+sample+'.root',"READ")
-        Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
+def GrabMCTrees(era = '2018'):
+    RootFile = {}
+    Tree = {}
+    nEvents = {}
+    sumw = {}
 
-    elif ("ggH_amcatnloFXFX" in sample):
-        RootFile[sample] = TFile(dirMC_94+'/'+sample+'.root',"READ")
-        Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
+    for i in range(0,len(SamplesMC[era])):
 
-    else:
-        RootFile[sample] = TFile.Open(dirMC_94+'/'+sample+'.root',"READ")
-        Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
+        sample = SamplesMC[era][i].rstrip('.root')
 
-    h_nevents = RootFile[sample].Get("Ana/nEvents")
-    h_sumw = RootFile[sample].Get("Ana/sumWeights")
 
-    if (h_nevents): nEvents[sample] = h_nevents.Integral()
-    else: nEvents[sample] = 0.
+        if ("NNLOPS" in sample):
+            RootFile[sample] = TFile(dirMC[era]+'/'+sample+'.root',"READ")
+            Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
 
-    if (h_sumw): sumw[sample] = h_sumw.Integral()
-    else: sumw[sample] = 0.
+        elif ("ggH_amcatnloFXFX" in sample):
+            RootFile[sample] = TFile(dirMC[era]+'/'+sample+'.root',"READ")
+            Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
 
-    if (not Tree[sample]): print sample+' has no passedEvents tree'
-    else:
-        print('{sample:37}\t nevents: {nevents:11}\t sumw: {sumw}'.format(
-            sample = sample, nevents = nEvents[sample], sumw = sumw[sample]))
+        else:
+            RootFile[sample] = TFile.Open(dirMC[era]+'/'+sample+'.root',"READ")
+            Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
 
-for i in range(0,len(SamplesData_94)):
-    break
-    sample = SamplesData_94[i].rstrip('.root')
+        h_nevents = RootFile[sample].Get("Ana/nEvents")
+        h_sumw = RootFile[sample].Get("Ana/sumWeights")
 
-    RootFile[sample] = TFile(dirData_94+'/'+sample+'.root',"READ")
+        if (h_nevents): nEvents[sample] = h_nevents.Integral()
+        else: nEvents[sample] = 0.
 
-    Tree[sample]  = RootFile[sample].Get("Ana/passedEvents")
+        if (h_sumw): sumw[sample] = h_sumw.Integral()
+        else: sumw[sample] = 0.
 
-    h_nevents = RootFile[sample].Get("nEvents")
-    h_sumw = RootFile[sample].Get("sumWeights")
+        if (not Tree[sample]): print sample+' has no passedEvents tree'
+        else:
+            print('{sample:37}\t nevents: {nevents:11}\t sumw: {sumw}'.format(
+                sample = sample, nevents = nEvents[sample], sumw = sumw[sample]))
 
-    if (h_nevents):
-        nEvents[sample] = h_nevents.Integral()
-        sumw[sample] = h_sumw.Integral()
-    else:
-        nEvents[sample] = 0.
-        sumw[sample] = 0.
-
-    if (not Tree[sample]): print sample+' has no passedEvents tree'
-    else:
-        print sample,"nevents",nEvents[sample],"sumw",sumw[sample]
-
+    return RootFile, Tree, nEvents, sumw

--- a/python/sample_shortnames.py
+++ b/python/sample_shortnames.py
@@ -1,4 +1,6 @@
-sample_shortnames = {
+sample_shortnames = {}
+
+sample_shortnames['2018'] = {
     'GluGluHToZZTo4L_M124_2018_slimmed' :'ggH_powheg_JHUgen_124',
     'GluGluHToZZTo4L_M125_2018_slimmed' :'ggH_powheg_JHUgen_125',
     'GluGluHToZZTo4L_M126_2018_slimmed' :'ggH_powheg_JHUgen_126',
@@ -10,7 +12,9 @@ sample_shortnames = {
     'ggH_amcatnloFXFX_2018_slimmed'     :'ggH_amcatnloFXFX_125',
 }
 
-background_samples = {
+background_samples = {}
+
+background_samples['2018'] = {
     'ZX4l_CR':'2018_noDuplicates.root',
     'ZX4l_CR_4e':'2018_noDuplicates.root',
     'ZX4l_CR_4mu':'2018_noDuplicates.root',


### PR DESCRIPTION
Adding the separation per data taking period for two initial modules:
* Adding the ```-y``` option (default "2018") for the efficiency module:
    * Stores the output files into the ```2018/datacardInputs``` folder
* Adding the ```-y``` option (default "2018") for the uncertainty modules (both the *unc and *njet* one):
    * Stores the output files into the ```2018/``` folder (removing it from the ```python``` folder it was currently being stored at)
 * Turing the input paths and sample names/shortnames into lists in order to be able to incorporate the per era additons:
     * Changes were made to both ```LoadData.py``` and ```sample_shortnames.py```
     * Mainly switching from arrays or simple dicts to lists of the same, i.e in order to access 2018 MC one would look for: dirMC -> dirMC['2018'].
 * Adding the ```-y``` option to the ```RunEverything.py``` macro.
  
  @ram1123 this PR is ready for testing from my side. If all goes well and the condor script is fixed for the 2D variables, we can initiate the synch with LLR on these two inputs. It would be good that @tjavaid and @qyguo test the code as we discussed last Tuesday before this is implemented as it will bring a bit more complexity to the code.